### PR TITLE
Implement issues #7 and #2: GraalVM Java-level events + multi-OS JFR samples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,15 +354,87 @@ jobs:
           path: jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}.jfr
           retention-days: ${{ env.TEMP_ARTIFACT_RETENTION_DAYS }}
 
+  create-jfr-graal:
+    name: Create JFR (GraalVM ${{ matrix.mode }})
+    needs: [changes, prepare-jfr]
+    if: needs.changes.outputs.collector == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        mode: [jvm, native]
+      fail-fast: false
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up GraalVM JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: graalvm
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Get cache key info
+        id: cache-info
+        run: |
+          set -euo pipefail
+          JAVA_VER=$(java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}')
+          CURRENT_MONTH=$(date +%Y-%m)
+          echo "java-version=$JAVA_VER" >> $GITHUB_OUTPUT
+          echo "month=$CURRENT_MONTH" >> $GITHUB_OUTPUT
+
+      - name: Restore cached GraalVM JFR
+        id: jfr-graal-cache
+        if: needs.changes.outputs.cache-mode == 'normal'
+        uses: actions/cache@v4
+        with:
+          path: jfr/sample_linux_graalvm_*.jfr
+          key: jfr-graalvm-${{ matrix.mode }}-${{ steps.cache-info.outputs.month }}-java${{ steps.cache-info.outputs.java-version }}
+
+      - name: Download JFC configuration
+        if: steps.jfr-graal-cache.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: jfc-config
+          path: .cache/
+
+      - name: Create GraalVM JFR (${{ matrix.mode }})
+        if: steps.jfr-graal-cache.outputs.cache-hit != 'true'
+        env:
+          MODE: ${{ matrix.mode }}
+          PLATFORM: linux
+        run: |
+          set -euo pipefail
+          python3 bin/releaser.py create_jfr_graal 2>&1 | tee create_jfr_graal_${{ matrix.mode }}.log
+
+      - name: Upload JFR creation log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jfr-graal-creation-log-${{ matrix.mode }}-${{ github.run_number }}
+          path: create_jfr_graal_${{ matrix.mode }}.log
+          retention-days: ${{ env.LOG_RETENTION_DAYS }}
+          if-no-files-found: ignore
+
+      - name: Upload GraalVM JFR files
+        uses: actions/upload-artifact@v4
+        with:
+          name: jfr-graalvm-${{ matrix.mode }}
+          path: jfr/sample_linux_graalvm_*.jfr
+          if-no-files-found: ignore
+          retention-days: ${{ env.TEMP_ARTIFACT_RETENTION_DAYS }}
+
   build:
     name: Build Collector
-    needs: [changes, prepare-jfr, create-jfr, test]
+    needs: [changes, prepare-jfr, create-jfr, create-jfr-graal, test]
     if: |
       always() &&
       needs.changes.outputs.collector == 'true' &&
       needs.prepare-jfr.result == 'success' &&
       needs.test.result == 'success' &&
-      (needs.create-jfr.result == 'success' || needs.create-jfr.result == 'skipped')
+      (needs.create-jfr.result == 'success' || needs.create-jfr.result == 'skipped') &&
+      (needs.create-jfr-graal.result == 'success' || needs.create-jfr-graal.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     outputs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -328,13 +328,15 @@ jobs:
           if-no-files-found: ignore
 
       - name: Verify JFR file created
+        id: verify-jfr
         if: steps.jfr-cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           JFR_FILE="jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}.jfr"
           if [ ! -f "$JFR_FILE" ]; then
-            echo "ERROR: JFR file not found: $JFR_FILE"
-            exit 1
+            echo "WARNING: JFR file not found: $JFR_FILE (GC may not be supported on this platform)"
+            echo "exists=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
           FILE_SIZE=$(wc -c < "$JFR_FILE")
           if [ "$FILE_SIZE" -lt ${{ env.MIN_JFR_FILE_SIZE_BYTES }} ]; then
@@ -342,8 +344,10 @@ jobs:
             exit 1
           fi
           echo "JFR file verified: $FILE_SIZE bytes"
+          echo "exists=true" >> $GITHUB_OUTPUT
 
       - name: Upload JFR file
+        if: steps.verify-jfr.outputs.exists == 'true' || steps.jfr-cache.outputs.cache-hit == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: jfr-${{ matrix.os }}-${{ matrix.gc }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,7 +299,9 @@ jobs:
         if: needs.changes.outputs.cache-mode == 'normal'
         uses: actions/cache@v4
         with:
-          path: jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}.jfr
+          path: |
+            jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}.jfr
+            jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}_events.jfr
           key: jfr-${{ matrix.os }}-${{ matrix.gc }}-${{ steps.cache-info.outputs.month }}-java${{ steps.cache-info.outputs.java-version }}
 
       - name: Download JFC configuration
@@ -351,7 +353,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jfr-${{ matrix.os }}-${{ matrix.gc }}
-          path: jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}.jfr
+          path: |
+            jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}.jfr
+            jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}_events.jfr
           retention-days: ${{ env.TEMP_ARTIFACT_RETENTION_DAYS }}
 
   create-jfr-graal:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -441,15 +441,22 @@ jobs:
           mkdir -p jfr
           find jfr-artifacts -name "*.jfr" -exec mv {} jfr/ \;
 
-          # Each GC option produces one JFR file per OS platform (ubuntu + macos + windows = 3)
-          EXPECTED_COUNT=$(( ${{ needs.prepare-jfr.outputs.gc-count }} * 3 ))
           ACTUAL_COUNT=$(ls -1 jfr/*.jfr 2>/dev/null | wc -l | tr -d ' ')
-
-          if [ "$ACTUAL_COUNT" -ne "$EXPECTED_COUNT" ]; then
-            echo "ERROR: Expected $EXPECTED_COUNT JFR files but found $ACTUAL_COUNT"
-            ls -lh jfr/ || echo "No files"
+          if [ "$ACTUAL_COUNT" -eq 0 ]; then
+            echo "ERROR: No JFR files found"
             exit 1
           fi
+
+          # Verify each platform contributed at least one file
+          for platform in linux macos windows; do
+            if ! ls jfr/sample_${platform}_*.jfr 1>/dev/null 2>&1; then
+              echo "ERROR: No JFR files found for platform: $platform"
+              ls -lh jfr/
+              exit 1
+            fi
+          done
+          echo "Found $ACTUAL_COUNT JFR files across all platforms"
+          ls -lh jfr/
 
       - name: Download JDK sources
         timeout-minutes: 60

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -677,6 +677,7 @@ jobs:
     needs: [changes, build]
     if: |
       always() &&
+      github.ref == 'refs/heads/main' &&
       (needs.build.result == 'success' || (needs.changes.outputs.website == 'true' && needs.build.result == 'skipped'))
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,13 +261,14 @@ jobs:
           retention-days: ${{ env.TEMP_ARTIFACT_RETENTION_DAYS }}
 
   create-jfr:
-    name: Create JFR (${{ matrix.gc }})
+    name: Create JFR (${{ matrix.os }}, ${{ matrix.gc }})
     needs: [changes, prepare-jfr]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
       matrix:
         gc: ${{ fromJSON(needs.prepare-jfr.outputs.gc-matrix) }}
+        os: [ubuntu-latest, macos-latest]
       fail-fast: false
 
     steps:
@@ -288,14 +289,15 @@ jobs:
           CURRENT_MONTH=$(date +%Y-%m)
           echo "java-version=$JAVA_VER" >> $GITHUB_OUTPUT
           echo "month=$CURRENT_MONTH" >> $GITHUB_OUTPUT
+          echo "platform=$(echo '${{ runner.os }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
-      - name: Restore cached JFR for ${{ matrix.gc }}
+      - name: Restore cached JFR for ${{ matrix.os }}, ${{ matrix.gc }}
         id: jfr-cache
         if: needs.changes.outputs.cache-mode == 'normal'
         uses: actions/cache@v4
         with:
-          path: jfr/sample_${{ matrix.gc }}.jfr
-          key: jfr-${{ matrix.gc }}-${{ steps.cache-info.outputs.month }}-java${{ steps.cache-info.outputs.java-version }}
+          path: jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}.jfr
+          key: jfr-${{ matrix.os }}-${{ matrix.gc }}-${{ steps.cache-info.outputs.month }}-java${{ steps.cache-info.outputs.java-version }}
 
       - name: Download JFC configuration
         if: steps.jfr-cache.outputs.cache-hit != 'true'
@@ -308,17 +310,18 @@ jobs:
         if: steps.jfr-cache.outputs.cache-hit != 'true'
         env:
           GC: ${{ matrix.gc }}
+          PLATFORM: ${{ steps.cache-info.outputs.platform }}
         run: |
           set -euo pipefail
           chmod +x bin/releaser.py
-          bin/releaser.py create_jfr 2>&1 | tee "create_jfr_${{ matrix.gc }}.log"
+          bin/releaser.py create_jfr 2>&1 | tee "create_jfr_${{ matrix.os }}_${{ matrix.gc }}.log"
 
       - name: Upload JFR creation log on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: jfr-creation-log-${{ matrix.gc }}-${{ github.run_number }}
-          path: create_jfr_${{ matrix.gc }}.log
+          name: jfr-creation-log-${{ matrix.os }}-${{ matrix.gc }}-${{ github.run_number }}
+          path: create_jfr_${{ matrix.os }}_${{ matrix.gc }}.log
           retention-days: ${{ env.LOG_RETENTION_DAYS }}
           if-no-files-found: ignore
 
@@ -326,7 +329,7 @@ jobs:
         if: steps.jfr-cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          JFR_FILE="jfr/sample_${{ matrix.gc }}.jfr"
+          JFR_FILE="jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}.jfr"
           if [ ! -f "$JFR_FILE" ]; then
             echo "ERROR: JFR file not found: $JFR_FILE"
             exit 1
@@ -341,8 +344,8 @@ jobs:
       - name: Upload JFR file
         uses: actions/upload-artifact@v4
         with:
-          name: jfr-${{ matrix.gc }}
-          path: jfr/sample_${{ matrix.gc }}.jfr
+          name: jfr-${{ matrix.os }}-${{ matrix.gc }}
+          path: jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}.jfr
           retention-days: ${{ env.TEMP_ARTIFACT_RETENTION_DAYS }}
 
   build:
@@ -434,10 +437,11 @@ jobs:
           set -euo pipefail
           mkdir -p jfr
           find jfr-artifacts -name "*.jfr" -exec mv {} jfr/ \;
-          
-          EXPECTED_COUNT="${{ needs.prepare-jfr.outputs.gc-count }}"
+
+          # Each GC option produces one JFR file per OS platform (ubuntu + macos = 2)
+          EXPECTED_COUNT=$(( ${{ needs.prepare-jfr.outputs.gc-count }} * 2 ))
           ACTUAL_COUNT=$(ls -1 jfr/*.jfr 2>/dev/null | wc -l | tr -d ' ')
-          
+
           if [ "$ACTUAL_COUNT" -ne "$EXPECTED_COUNT" ]; then
             echo "ERROR: Expected $EXPECTED_COUNT JFR files but found $ACTUAL_COUNT"
             ls -lh jfr/ || echo "No files"
@@ -457,7 +461,7 @@ jobs:
           set -euo pipefail
           chmod +x bin/releaser.py
           bin/releaser.py build_parser 2>&1 | tee build_parser.log
-          bin/releaser.py build_versions 2>&1 | tee build_versions.log
+          PLATFORM=linux bin/releaser.py build_versions 2>&1 | tee build_versions.log
           bin/releaser.py build 2>&1 | tee build.log
 
       - name: Install to local Maven repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,10 +265,13 @@ jobs:
     needs: [changes, prepare-jfr]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         gc: ${{ fromJSON(needs.prepare-jfr.outputs.gc-matrix) }}
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
 
     steps:
@@ -438,8 +441,8 @@ jobs:
           mkdir -p jfr
           find jfr-artifacts -name "*.jfr" -exec mv {} jfr/ \;
 
-          # Each GC option produces one JFR file per OS platform (ubuntu + macos = 2)
-          EXPECTED_COUNT=$(( ${{ needs.prepare-jfr.outputs.gc-count }} * 2 ))
+          # Each GC option produces one JFR file per OS platform (ubuntu + macos + windows = 3)
+          EXPECTED_COUNT=$(( ${{ needs.prepare-jfr.outputs.gc-count }} * 3 ))
           ACTUAL_COUNT=$(ls -1 jfr/*.jfr 2>/dev/null | wc -l | tr -d ' ')
 
           if [ "$ACTUAL_COUNT" -ne "$EXPECTED_COUNT" ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,10 +260,11 @@ jobs:
             .cache/renaissance.jar
           retention-days: ${{ env.TEMP_ARTIFACT_RETENTION_DAYS }}
 
-  create-jfr:
-    name: Create JFR (${{ matrix.os }}, ${{ matrix.gc }})
+  create-jfr-linux:
+    name: Create JFR (ubuntu-latest, ${{ matrix.gc }})
     needs: [changes, prepare-jfr]
-    runs-on: ${{ matrix.os }}
+    if: needs.changes.outputs.collector == 'true'
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:
       run:
@@ -271,7 +272,104 @@ jobs:
     strategy:
       matrix:
         gc: ${{ fromJSON(needs.prepare-jfr.outputs.gc-matrix) }}
-        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'sapmachine'
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Get cache key info
+        id: cache-info
+        run: |
+          set -euo pipefail
+          JAVA_VER=$(java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}')
+          CURRENT_MONTH=$(date +%Y-%m)
+          echo "java-version=$JAVA_VER" >> $GITHUB_OUTPUT
+          echo "month=$CURRENT_MONTH" >> $GITHUB_OUTPUT
+          echo "platform=linux" >> $GITHUB_OUTPUT
+
+      - name: Restore cached JFR for ubuntu-latest, ${{ matrix.gc }}
+        id: jfr-cache
+        if: needs.changes.outputs.cache-mode == 'normal'
+        uses: actions/cache@v4
+        with:
+          path: |
+            jfr/sample_linux_${{ matrix.gc }}.jfr
+            jfr/sample_linux_${{ matrix.gc }}_events.jfr
+          key: jfr-ubuntu-latest-${{ matrix.gc }}-${{ steps.cache-info.outputs.month }}-java${{ steps.cache-info.outputs.java-version }}
+
+      - name: Download JFC configuration
+        if: steps.jfr-cache.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: jfc-config
+          path: .cache/
+
+      - name: Create JFR for ${{ matrix.gc }}
+        if: steps.jfr-cache.outputs.cache-hit != 'true'
+        env:
+          GC: ${{ matrix.gc }}
+          PLATFORM: linux
+        run: |
+          set -euo pipefail
+          python3 bin/releaser.py create_jfr 2>&1 | tee "create_jfr_ubuntu-latest_${{ matrix.gc }}.log"
+
+      - name: Upload JFR creation log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jfr-creation-log-ubuntu-latest-${{ matrix.gc }}-${{ github.run_number }}
+          path: create_jfr_ubuntu-latest_${{ matrix.gc }}.log
+          retention-days: ${{ env.LOG_RETENTION_DAYS }}
+          if-no-files-found: ignore
+
+      - name: Verify JFR file created
+        id: verify-jfr
+        if: steps.jfr-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          JFR_FILE="jfr/sample_linux_${{ matrix.gc }}.jfr"
+          if [ ! -f "$JFR_FILE" ]; then
+            echo "WARNING: JFR file not found: $JFR_FILE (GC may not be supported)"
+            echo "exists=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          FILE_SIZE=$(wc -c < "$JFR_FILE")
+          if [ "$FILE_SIZE" -lt ${{ env.MIN_JFR_FILE_SIZE_BYTES }} ]; then
+            echo "ERROR: JFR file too small: $FILE_SIZE bytes"
+            exit 1
+          fi
+          echo "JFR file verified: $FILE_SIZE bytes"
+          echo "exists=true" >> $GITHUB_OUTPUT
+
+      - name: Upload JFR file
+        if: steps.verify-jfr.outputs.exists == 'true' || steps.jfr-cache.outputs.cache-hit == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: jfr-ubuntu-latest-${{ matrix.gc }}
+          path: |
+            jfr/sample_linux_${{ matrix.gc }}.jfr
+            jfr/sample_linux_${{ matrix.gc }}_events.jfr
+          retention-days: ${{ env.TEMP_ARTIFACT_RETENTION_DAYS }}
+
+  create-jfr-other:
+    name: Create JFR (${{ matrix.os }}, UseG1GC)
+    needs: [changes, prepare-jfr]
+    if: needs.changes.outputs.collector == 'true'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
       fail-fast: false
 
     steps:
@@ -294,15 +392,15 @@ jobs:
           echo "month=$CURRENT_MONTH" >> $GITHUB_OUTPUT
           echo "platform=$(echo '${{ runner.os }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
-      - name: Restore cached JFR for ${{ matrix.os }}, ${{ matrix.gc }}
+      - name: Restore cached JFR for ${{ matrix.os }}, UseG1GC
         id: jfr-cache
         if: needs.changes.outputs.cache-mode == 'normal'
         uses: actions/cache@v4
         with:
           path: |
-            jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}.jfr
-            jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}_events.jfr
-          key: jfr-${{ matrix.os }}-${{ matrix.gc }}-${{ steps.cache-info.outputs.month }}-java${{ steps.cache-info.outputs.java-version }}
+            jfr/sample_${{ steps.cache-info.outputs.platform }}_UseG1GC.jfr
+            jfr/sample_${{ steps.cache-info.outputs.platform }}_UseG1GC_events.jfr
+          key: jfr-${{ matrix.os }}-UseG1GC-${{ steps.cache-info.outputs.month }}-java${{ steps.cache-info.outputs.java-version }}
 
       - name: Download JFC configuration
         if: steps.jfr-cache.outputs.cache-hit != 'true'
@@ -311,21 +409,21 @@ jobs:
           name: jfc-config
           path: .cache/
 
-      - name: Create JFR for ${{ matrix.gc }}
+      - name: Create JFR for UseG1GC
         if: steps.jfr-cache.outputs.cache-hit != 'true'
         env:
-          GC: ${{ matrix.gc }}
+          GC: UseG1GC
           PLATFORM: ${{ steps.cache-info.outputs.platform }}
         run: |
           set -euo pipefail
-          python3 bin/releaser.py create_jfr 2>&1 | tee "create_jfr_${{ matrix.os }}_${{ matrix.gc }}.log"
+          python3 bin/releaser.py create_jfr 2>&1 | tee "create_jfr_${{ matrix.os }}_UseG1GC.log"
 
       - name: Upload JFR creation log on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: jfr-creation-log-${{ matrix.os }}-${{ matrix.gc }}-${{ github.run_number }}
-          path: create_jfr_${{ matrix.os }}_${{ matrix.gc }}.log
+          name: jfr-creation-log-${{ matrix.os }}-UseG1GC-${{ github.run_number }}
+          path: create_jfr_${{ matrix.os }}_UseG1GC.log
           retention-days: ${{ env.LOG_RETENTION_DAYS }}
           if-no-files-found: ignore
 
@@ -334,9 +432,9 @@ jobs:
         if: steps.jfr-cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          JFR_FILE="jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}.jfr"
+          JFR_FILE="jfr/sample_${{ steps.cache-info.outputs.platform }}_UseG1GC.jfr"
           if [ ! -f "$JFR_FILE" ]; then
-            echo "WARNING: JFR file not found: $JFR_FILE (GC may not be supported on this platform)"
+            echo "WARNING: JFR file not found: $JFR_FILE"
             echo "exists=false" >> $GITHUB_OUTPUT
             exit 0
           fi
@@ -352,10 +450,10 @@ jobs:
         if: steps.verify-jfr.outputs.exists == 'true' || steps.jfr-cache.outputs.cache-hit == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: jfr-${{ matrix.os }}-${{ matrix.gc }}
+          name: jfr-${{ matrix.os }}-UseG1GC
           path: |
-            jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}.jfr
-            jfr/sample_${{ steps.cache-info.outputs.platform }}_${{ matrix.gc }}_events.jfr
+            jfr/sample_${{ steps.cache-info.outputs.platform }}_UseG1GC.jfr
+            jfr/sample_${{ steps.cache-info.outputs.platform }}_UseG1GC_events.jfr
           retention-days: ${{ env.TEMP_ARTIFACT_RETENTION_DAYS }}
 
   create-jfr-graal:
@@ -431,13 +529,14 @@ jobs:
 
   build:
     name: Build Collector
-    needs: [changes, prepare-jfr, create-jfr, create-jfr-graal, test]
+    needs: [changes, prepare-jfr, create-jfr-linux, create-jfr-other, create-jfr-graal, test]
     if: |
       always() &&
       needs.changes.outputs.collector == 'true' &&
       needs.prepare-jfr.result == 'success' &&
       needs.test.result == 'success' &&
-      (needs.create-jfr.result == 'success' || needs.create-jfr.result == 'skipped') &&
+      (needs.create-jfr-linux.result == 'success' || needs.create-jfr-linux.result == 'skipped') &&
+      (needs.create-jfr-other.result == 'success' || needs.create-jfr-other.result == 'skipped') &&
       (needs.create-jfr-graal.result == 'success' || needs.create-jfr-graal.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -316,8 +316,7 @@ jobs:
           PLATFORM: ${{ steps.cache-info.outputs.platform }}
         run: |
           set -euo pipefail
-          chmod +x bin/releaser.py
-          bin/releaser.py create_jfr 2>&1 | tee "create_jfr_${{ matrix.os }}_${{ matrix.gc }}.log"
+          python3 bin/releaser.py create_jfr 2>&1 | tee "create_jfr_${{ matrix.os }}_${{ matrix.gc }}.log"
 
       - name: Upload JFR creation log on failure
         if: failure()

--- a/bin/releaser.py
+++ b/bin/releaser.py
@@ -493,6 +493,14 @@ def create_jfr(gc_option: str = None, force: bool = False):
         print(f"JFR file {jfr_file} already exists and is up to date")
         return
     if gc_option:
+        # Check that the GC flag is supported before running the full benchmark
+        check = subprocess.run(["java", "-XX:+" + gc_option, "-version"],
+                               capture_output=True)
+        if check.returncode != 0:
+            print(f"Skipping {gc_option}: not supported on this JVM/platform "
+                  f"({check.stderr.decode('utf-8', errors='replace').splitlines()[0] if check.stderr else 'unknown error'})",
+                  file=sys.stderr)
+            return
         print(f"Creating JFR file for GC option {gc_option}")
         try:
             execute(["java",

--- a/bin/releaser.py
+++ b/bin/releaser.py
@@ -579,13 +579,86 @@ def add_examples(repo: Repo):
         gc = gc_option[3:]
         label = f"{platform}_{gc}"
         description = f"Run of renaissance benchmark with {gc} on Java {java_version().strip()} ({platform})"
+        jfr_file = jfr_file_name(gc_option, platform)
+        if not os.path.exists(jfr_file):
+            print(f"Skipping {label}: JFR file not found: {jfr_file}")
+            continue
         execute(
             f"java -cp {get_parser_or_build()} me.bechberger.collector.ExampleAdderKt {metadata_file} "
-            f"{label} \"{description}\" {jfr_file_name(gc_option, platform)} {metadata_file}")
+            f"--platform={platform} {label} \"{description}\" {jfr_file} {metadata_file}")
+
+
+GRAALVM_SAMPLE_APP_SRC = f"{CURRENT_DIR}/src/main/java/jfr_sample/Main.java"
+GRAALVM_SAMPLE_APP_OUT = f"{CURRENT_DIR}/.cache/jfr_sample_out"
+GRAALVM_SAMPLE_APP_JAR = f"{CURRENT_DIR}/.cache/jfr_sample_app.jar"
+GRAALVM_SAMPLE_APP_BIN = f"{CURRENT_DIR}/jfr_sample_app"
+
+
+def graalvm_jfr_file_name(mode: str, gc: str = "native") -> str:
+    p = get_platform()
+    suffix = gc if mode == "jvm" else "native"
+    return f"{JFR_FOLDER}/sample_{p}_graalvm_{suffix}.jfr"
+
+
+def create_jfr_graalvm_native():
+    """Compile the tiny JFR sample app to native image and run it with JFR enabled."""
+    if not os.path.exists(JFC_FILE):
+        create_jfc()
+    jfr_file = graalvm_jfr_file_name("native")
+    os.makedirs(GRAALVM_SAMPLE_APP_OUT, exist_ok=True)
+    execute(f"javac -d {GRAALVM_SAMPLE_APP_OUT} {GRAALVM_SAMPLE_APP_SRC}")
+    execute(f"jar -cfe {GRAALVM_SAMPLE_APP_JAR} jfr_sample.Main -C {GRAALVM_SAMPLE_APP_OUT} .")
+    execute(f"native-image --enable-monitoring=jfr -jar {GRAALVM_SAMPLE_APP_JAR} "
+            f"{GRAALVM_SAMPLE_APP_BIN}")
+    execute([GRAALVM_SAMPLE_APP_BIN,
+             f"-XX:StartFlightRecording=filename={jfr_file},settings={JFC_FILE},duration=18s"])
+
+
+def create_jfr_graal(force: bool = False):
+    """Create JFR samples using GraalVM. MODE env var selects 'jvm' (default) or 'native'."""
+    mode = os.getenv("MODE", "jvm")
+    if mode == "native":
+        create_jfr_graalvm_native()
+    else:
+        if not os.path.exists(JFC_FILE):
+            create_jfc()
+        if not os.path.exists(RENAISSANCE_JAR):
+            download_benchmarks()
+        gc_option = "UseG1GC"
+        jfr_file = graalvm_jfr_file_name("jvm", "G1GC")
+        if os.path.exists(jfr_file) and not force:
+            print(f"GraalVM JVM JFR file already exists: {jfr_file}")
+            return
+        execute(["java",
+                 f"-XX:StartFlightRecording=filename={jfr_file},settings={JFC_FILE}",
+                 "-XX:+" + gc_option, "-jar", RENAISSANCE_JAR, "-t", "5", "-r", "1", "all"])
+
+
+def add_graal_examples(repo: Repo):
+    """Add GraalVM JFR sample examples to the metadata."""
+    import glob as _glob
+    metadata_file = meta_file_name(repo)
+    graal_files = sorted(_glob.glob(f"{JFR_FOLDER}/sample_*_graalvm_*.jfr"))
+    if not graal_files:
+        print("No GraalVM JFR files found, skipping graal examples")
+        return
+    for f in graal_files:
+        base = os.path.basename(f)[len("sample_"):-len(".jfr")]  # e.g. linux_graalvm_G1GC
+        parts = base.split("_graalvm_")
+        plat, suffix = parts[0], parts[1]  # linux, G1GC or native
+        label = f"graalvm_{plat}_{suffix}"
+        if suffix == "native":
+            desc = f"GraalVM Native Image JFR recording ({plat})"
+            platform_tag = "graalvm-native"
+        else:
+            desc = f"GraalVM JVM with {suffix} on {plat}"
+            platform_tag = "graalvm"
+        execute(
+            f"java -cp {get_parser_or_build()} me.bechberger.collector.ExampleAdderKt "
+            f"{metadata_file} --platform={platform_tag} {label} \"{desc}\" {f} {metadata_file}")
 
 
 def add_additional_descriptions(repo: Repo):
-    metadata_file = meta_file_name(repo)
     log(f"Add additional descriptions for version {repo.version} via AI")
     execute(
         f"java -cp {get_parser_or_build()} me.bechberger.collector.AdditionalDescriptionAdderKt {metadata_file} "
@@ -651,6 +724,8 @@ def build_version(repo: Repo, force: bool = False):
     execute(f"cp {meta_file} {meta_wo_examples}")
     print(f"Add examples from JFR files for version {repo.version}")
     add_examples(repo)
+    print(f"Add GraalVM examples from JFR files for version {repo.version}")
+    add_graal_examples(repo)
     print(f"Add source code context for version {repo.version}")
     add_source_code_context(repo)
     add_ai_generated_descriptions(repo)
@@ -788,10 +863,11 @@ class CLIArgs:
 
 def parse_cli_args() -> CLIArgs:
     available_commands = ["versions", "download_urls", "download", "list_jdk_versions", "download_jdk_version",
-                          "build_parser", "list_gc_options", "build_jfc", "create_jfr", "build_versions",
+                          "build_parser", "list_gc_options", "build_jfc", "create_jfr", "create_jfr_graal",
+                          "build_versions",
                           "build", "deploy_mvn", "deploy_gh", "deploy",
                           "deploy_release", "clear", "all", "tags"]
-    forcable_commands = ["all", "create_jfr", "build_versions"]
+    forcable_commands = ["all", "create_jfr", "create_jfr_graal", "build_versions"]
     commands = []
     forced_commands = []
     jdk_version_arg = None
@@ -848,6 +924,7 @@ def cli():
         "list_gc_options": lambda: print(" ".join(list_gc_options())),
         "build_jfc": build_jfc,
         "create_jfr": create_jfr,
+        "create_jfr_graal": create_jfr_graal,
         "build_versions": build_versions,
         "build": build,
         "deploy_mvn": lambda: deploy_maven(snapshot=True),

--- a/bin/releaser.py
+++ b/bin/releaser.py
@@ -143,6 +143,27 @@ def download_file(url, path: str, retention: int = CACHE_TIME) -> str:
     return cache_path
 
 
+GRAAL_JFR_DOCS_URL = f"https://raw.githubusercontent.com/{GRAAL_REPO}/master/docs/reference-manual/native-image/JFR.md"
+GRAAL_SUPPORTED_EVENTS_CACHE = f"{CACHE_DIR}/graal_supported_events.json"
+# Refresh weekly — the list rarely changes between GraalVM releases
+GRAAL_EVENTS_CACHE_TIME = 60 * 60 * 24 * 7
+
+
+def fetch_graal_supported_events() -> List[str]:
+    """Fetch the list of Java-level JDK JFR events supported by GraalVM Native Image
+    by parsing the oracle/graal JFR.md documentation."""
+    md_path = download_file(GRAAL_JFR_DOCS_URL, "graal_jfr.md", retention=GRAAL_EVENTS_CACHE_TIME)
+    events = []
+    with open(md_path) as f:
+        for line in f:
+            # Match table cells containing jdk.EventName (with optional footnote markers like [^1])
+            for word in line.split():
+                word = word.strip("|` \t")
+                if word.startswith("jdk.") and word.replace("jdk.", "").isidentifier():
+                    events.append(word[len("jdk."):])
+    return list(dict.fromkeys(events))  # deduplicate, preserve order
+
+
 def download_json(url, path: str) -> Any:
     """ Download the JSON file from the given URL and save it to the given path, return the JSON object """
     with open(download_file(url, path)) as f:
@@ -397,8 +418,25 @@ def get_parser_or_build() -> str:
 GC_OPTIONS = []
 
 
-def jfr_file_name(gc_options: str) -> str:
-    return f"{JFR_FOLDER}/sample_{gc_options}.jfr"
+def get_platform() -> str:
+    """Return a short lowercase platform identifier.
+    In CI, set the PLATFORM env var to ${{ runner.os }} (Linux, macOS, Windows).
+    Locally falls back to sys.platform."""
+    env = os.getenv("PLATFORM")
+    if env:
+        return env.lower()
+    import sys as _sys
+    p = _sys.platform
+    if p.startswith("darwin"):
+        return "macos"
+    if p.startswith("win"):
+        return "windows"
+    return "linux"
+
+
+def jfr_file_name(gc_options: str, platform: str = None) -> str:
+    p = platform or get_platform()
+    return f"{JFR_FOLDER}/sample_{p}_{gc_options}.jfr"
 
 
 def list_gc_options() -> List[str]:
@@ -505,8 +543,20 @@ def add_graal_events(repo: Repo):
     execute(
         f"java -cp {get_parser_or_build()} me.bechberger.collector.GraalEventAdderKt {metadata_file} {graal_folder(graal_version)} "
         f"{graal_version.url} {graal_version.graal_version} {graal_version.tag} {metadata_file}")
+    add_java_level_graal_events(repo)
 
 
+def add_java_level_graal_events(repo: Repo):
+    """Mark Java-level JDK JFR events supported by GraalVM Native Image using the oracle/graal JFR.md docs."""
+    metadata_file = meta_file_name(repo)
+    events = fetch_graal_supported_events()
+    if not events:
+        print("Warning: no Java-level Graal events fetched from JFR.md — skipping")
+        return
+    events_args = " ".join(events)
+    execute(
+        f"java -cp {get_parser_or_build()} me.bechberger.collector.MarkJavaLevelGraalEventsKt "
+        f"{metadata_file} {events_args} {metadata_file}")
 
 def java_version() -> str:
     return subprocess.check_output(
@@ -516,13 +566,14 @@ def java_version() -> str:
 
 def add_examples(repo: Repo):
     metadata_file = meta_file_name(repo)
+    platform = get_platform()
     for gc_option in list_gc_options():
         gc = gc_option[3:]
-        label = gc
-        description = f"Run of renaissance benchmark with {gc} on {java_version()}"
+        label = f"{platform}_{gc}"
+        description = f"Run of renaissance benchmark with {gc} on Java {java_version().strip()} ({platform})"
         execute(
             f"java -cp {get_parser_or_build()} me.bechberger.collector.ExampleAdderKt {metadata_file} "
-            f"{label} \"{description}\" {jfr_file_name(gc_option)} {metadata_file}")
+            f"{label} \"{description}\" {jfr_file_name(gc_option, platform)} {metadata_file}")
 
 
 def add_additional_descriptions(repo: Repo):

--- a/bin/releaser.py
+++ b/bin/releaser.py
@@ -454,10 +454,16 @@ def run_sample_app_jfr(gc_option: str, platform: str = None):
     jfr_file = jfr_sample_app_file_name(gc_option, platform)
     os.makedirs(out_dir, exist_ok=True)
     if not os.path.exists(app_jar):
-        execute(f"javac -d {out_dir} {GRAALVM_SAMPLE_APP_SRC}")
+        execute(f"javac --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED "
+                f"-d {out_dir} {GRAALVM_SAMPLE_APP_SRC}")
         execute(f"jar -cfe {app_jar} jfr_sample.Main -C {out_dir} .")
     execute(["java",
-             f"-XX:StartFlightRecording=filename={jfr_file},settings={JFC_FILE},duration=20s",
+             "--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
+             "-Djdk.attach.allowAttachSelf=true",
+             "-XX:+UnlockDiagnosticVMOptions",
+             "-XX:DiagnoseSyncOnValueBasedClasses=2",
+             "-XX:NativeMemoryTracking=summary",
+             f"-XX:StartFlightRecording=filename={jfr_file},settings={JFC_FILE},duration=27s",
              "-XX:+" + gc_option, "-jar", app_jar])
 
 
@@ -491,6 +497,11 @@ def create_jfc():
     content = _re.sub(
         r'(name="jdk\.DeprecatedInvocation".*?<setting name="level">)[^<]+(</setting>)',
         r'\g<1>all\2',
+        content, flags=_re.DOTALL)
+    # Shorten ThreadDump period so it fires within a 20s recording
+    content = _re.sub(
+        r'(name="jdk\.ThreadDump".*?<setting name="period"[^>]*>)\s*60 s\s*(<)',
+        r'\g<1>10 s\2',
         content, flags=_re.DOTALL)
     with open(JFC_FILE, "w") as f2:
         f2.write(content)

--- a/bin/releaser.py
+++ b/bin/releaser.py
@@ -612,9 +612,13 @@ def build_version(repo: Repo, force: bool = False):
     download_repo_if_not_exists(repo)
     meta_file = meta_file_name(repo)
     meta_wo_examples = meta_file_name(repo, wo_examples=True)
-    # copy metadata
-    generated_example_min_mtime = min(os.path.getmtime(jfr_file_name(gc_option))
-                                      for gc_option in list_gc_options())
+    # copy metadata — consider all JFR files present regardless of platform
+    import glob as _glob
+    all_jfr_files = _glob.glob(f"{JFR_FOLDER}/sample_*.jfr")
+    generated_example_min_mtime = min(
+        (os.path.getmtime(f) for f in all_jfr_files),
+        default=0
+    )
     if os.path.exists(meta_file):
         meta_file_mtime = os.path.getmtime(meta_file)
         if not force and meta_file_mtime > \

--- a/bin/releaser.py
+++ b/bin/releaser.py
@@ -439,6 +439,28 @@ def jfr_file_name(gc_options: str, platform: str = None) -> str:
     return f"{JFR_FOLDER}/sample_{p}_{gc_options}.jfr"
 
 
+def jfr_sample_app_file_name(gc_options: str, platform: str = None) -> str:
+    """JFR file produced by the sample app run alongside renaissance."""
+    p = platform or get_platform()
+    return f"{JFR_FOLDER}/sample_{p}_{gc_options}_events.jfr"
+
+
+def run_sample_app_jfr(gc_option: str, platform: str = None):
+    """Run the jfr_sample app with JFR to produce additional event coverage."""
+    if not os.path.exists(GRAALVM_SAMPLE_APP_SRC):
+        return
+    out_dir = GRAALVM_SAMPLE_APP_OUT
+    app_jar = GRAALVM_SAMPLE_APP_JAR
+    jfr_file = jfr_sample_app_file_name(gc_option, platform)
+    os.makedirs(out_dir, exist_ok=True)
+    if not os.path.exists(app_jar):
+        execute(f"javac -d {out_dir} {GRAALVM_SAMPLE_APP_SRC}")
+        execute(f"jar -cfe {app_jar} jfr_sample.Main -C {out_dir} .")
+    execute(["java",
+             f"-XX:StartFlightRecording=filename={jfr_file},settings={JFC_FILE},duration=20s",
+             "-XX:+" + gc_option, "-jar", app_jar])
+
+
 def list_gc_options() -> List[str]:
     """ List all GC options for the current JDK """
     global GC_OPTIONS
@@ -453,7 +475,7 @@ def list_gc_options() -> List[str]:
 
 
 def create_jfc():
-    """ Create a maximalist JFC file: all events enabled, thresholds zeroed """
+    """ Create a maximalist JFC file: all events enabled, thresholds zeroed, level=all """
     import re as _re
     print("Creating JFC configuration file...")
     with open(os.getenv("JAVA_HOME") + "/lib/jfr/profile.jfc") as f:
@@ -465,6 +487,11 @@ def create_jfc():
         r'(<setting name="threshold"[^>]*>)[^<]+(<)',
         r'\g<1>0 ms\2',
         content)
+    # Use level=all for DeprecatedInvocation to capture all deprecated calls (not just forRemoval)
+    content = _re.sub(
+        r'(name="jdk\.DeprecatedInvocation".*?<setting name="level">)[^<]+(</setting>)',
+        r'\g<1>all\2',
+        content, flags=_re.DOTALL)
     with open(JFC_FILE, "w") as f2:
         f2.write(content)
     print(f"✅ JFC file created at {JFC_FILE}")
@@ -514,6 +541,8 @@ def create_jfr(gc_option: str = None, force: bool = False):
             if not os.path.exists(jfr_file_name(gc_option)):
                 raise ex
             print(f"Caught a Java error", file=sys.stderr)
+        # Also run the sample app to capture additional event types not in renaissance
+        run_sample_app_jfr(gc_option)
     else:
         print(
             f"Creating JFR file for GC options: {', '.join(list_gc_options())}")
@@ -586,9 +615,12 @@ def add_examples(repo: Repo):
         if not os.path.exists(jfr_file):
             print(f"Skipping {label}: JFR file not found: {jfr_file}")
             continue
+        # Include the sample app JFR if present (provides additional event coverage)
+        sample_file = jfr_sample_app_file_name(gc_option, platform)
+        files_arg = f"{jfr_file},{sample_file}" if os.path.exists(sample_file) else jfr_file
         execute(
             f"java -cp {get_parser_or_build()} me.bechberger.collector.ExampleAdderKt {metadata_file} "
-            f"--platform={platform} {label} \"{description}\" {jfr_file} {metadata_file}")
+            f"--platform={platform} {label} \"{description}\" {files_arg} {metadata_file}")
 
 
 GRAALVM_SAMPLE_APP_SRC = f"{CURRENT_DIR}/src/main/java/jfr_sample/Main.java"

--- a/bin/releaser.py
+++ b/bin/releaser.py
@@ -705,6 +705,7 @@ def add_graal_examples(repo: Repo):
 
 
 def add_additional_descriptions(repo: Repo):
+    metadata_file = meta_file_name(repo)
     log(f"Add additional descriptions for version {repo.version} via AI")
     execute(
         f"java -cp {get_parser_or_build()} me.bechberger.collector.AdditionalDescriptionAdderKt {metadata_file} "

--- a/bin/releaser.py
+++ b/bin/releaser.py
@@ -453,17 +453,20 @@ def list_gc_options() -> List[str]:
 
 
 def create_jfc():
-    """ Create a JFC file for the current JDK """
+    """ Create a maximalist JFC file: all events enabled, thresholds zeroed """
+    import re as _re
     print("Creating JFC configuration file...")
     with open(os.getenv("JAVA_HOME") + "/lib/jfr/profile.jfc") as f:
-        lines = []
-        for line in f.readlines():
-            if 'name="enabled"' in line:
-                lines.append(line.replace(">false<", ">true<"))
-            else:
-                lines.append(line)
-        with open(JFC_FILE, "w") as f2:
-            f2.write("\n".join(lines))
+        content = f.read()
+    # Enable all disabled events
+    content = content.replace(">false<", ">true<")
+    # Zero all thresholds so short-duration events are captured
+    content = _re.sub(
+        r'(<setting name="threshold"[^>]*>)[^<]+(<)',
+        r'\g<1>0 ms\2',
+        content)
+    with open(JFC_FILE, "w") as f2:
+        f2.write(content)
     print(f"✅ JFC file created at {JFC_FILE}")
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>2.2.21</version>
+                <version>2.2.0</version>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -200,7 +200,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>2.2.21</version>
+            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
@@ -250,7 +250,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test-junit5</artifactId>
-            <version>2.2.21</version>
+            <version>2.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,12 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.10.3</version>
             <scope>test</scope>

--- a/pom_loader.xml
+++ b/pom_loader.xml
@@ -57,7 +57,7 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>2.2.21</version>
+                <version>2.2.0</version>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -190,7 +190,25 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>2.2.21</version>
+            <version>2.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit5</artifactId>
+            <version>2.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.3</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>

--- a/src/main/java/jfr_sample/Main.java
+++ b/src/main/java/jfr_sample/Main.java
@@ -1,0 +1,21 @@
+package jfr_sample;
+
+import java.util.ArrayList;
+
+/**
+ * Minimal JFR event generator for GraalVM Native Image recording.
+ * Runs ~20 seconds, allocating objects to trigger GC/thread/memory JFR events.
+ */
+public class Main {
+    public static void main(String[] args) throws Exception {
+        long end = System.currentTimeMillis() + 20_000;
+        ArrayList<byte[]> list = new ArrayList<>();
+        while (System.currentTimeMillis() < end) {
+            list.add(new byte[1024]);
+            if (list.size() > 1000) {
+                list.clear();
+            }
+            Thread.sleep(1);
+        }
+    }
+}

--- a/src/main/java/jfr_sample/Main.java
+++ b/src/main/java/jfr_sample/Main.java
@@ -1,21 +1,212 @@
 package jfr_sample;
 
-import java.util.ArrayList;
+import java.io.*;
+import java.net.*;
+import java.nio.channels.*;
+import java.nio.file.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.locks.*;
 
 /**
- * Minimal JFR event generator for GraalVM Native Image recording.
- * Runs ~20 seconds, allocating objects to trigger GC/thread/memory JFR events.
+ * Maximalist JFR event generator for GraalVM recordings.
+ * Triggers as many Java-level JFR event types as possible.
  */
 public class Main {
+
+    static volatile Object sink;
+    static final Object lock = new Object();
+
     public static void main(String[] args) throws Exception {
         long end = System.currentTimeMillis() + 20_000;
-        ArrayList<byte[]> list = new ArrayList<>();
-        while (System.currentTimeMillis() < end) {
-            list.add(new byte[1024]);
-            if (list.size() > 1000) {
-                list.clear();
+
+        // ThreadStart/ThreadEnd, ThreadCPULoad, ThreadAllocationStatistics
+        ExecutorService pool = Executors.newFixedThreadPool(4);
+        for (int t = 0; t < 4; t++) {
+            pool.submit(() -> {
+                while (!Thread.currentThread().isInterrupted()) {
+                    allocateAndGC();
+                    try { Thread.sleep(5); } catch (InterruptedException e) { break; }
+                }
+            });
+        }
+
+        // VirtualThreadStart, VirtualThreadEnd
+        try {
+            ExecutorService vPool = (ExecutorService)
+                Executors.class.getMethod("newVirtualThreadPerTaskExecutor").invoke(null);
+            for (int i = 0; i < 20; i++) {
+                final int n = i;
+                vPool.submit(() -> {
+                    try { Thread.sleep(1); } catch (InterruptedException e) {}
+                    allocateSmall(n);
+                });
             }
-            Thread.sleep(1);
+            vPool.shutdown();
+            vPool.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (NoSuchMethodException e) { /* JDK < 21 */ }
+
+        // ThreadDump (trigger once at start)
+        triggerThreadDump();
+
+        // TLSHandshake, X509Certificate, X509Validation (HTTPS)
+        httpsRequest();
+
+        // NativeMemoryUsage (requires NMT — best-effort, may be 0 without flag)
+        // Deserialization
+        deserialization();
+
+        while (System.currentTimeMillis() < end) {
+            // GarbageCollection, GCHeapSummary, G1*, ObjectAllocation*, Promote*
+            allocateAndGC();
+
+            // ClassLoad, ClassDefine
+            loadClasses();
+
+            // JavaMonitorEnter, JavaMonitorWait, JavaMonitorInflate, JavaMonitorNotify
+            monitorContention();
+
+            // FileRead, FileWrite
+            fileIO();
+
+            // FileForce (FileChannel.force)
+            fileForce();
+
+            // SocketRead, SocketWrite
+            socketIO();
+
+            // ThreadSleep
+            Thread.sleep(2);
+
+            // ThreadPark
+            LockSupport.parkNanos(1_000_000);
+
+            // JavaExceptionThrow
+            throwAndCatch();
+
+            // SystemGC → GarbageCollection, GCHeapSummary
+            System.gc();
+        }
+
+        pool.shutdownNow();
+        pool.awaitTermination(2, TimeUnit.SECONDS);
+    }
+
+    static void allocateAndGC() {
+        List<byte[]> list = new ArrayList<>(500);
+        for (int i = 0; i < 500; i++) list.add(new byte[4096]);
+        sink = list;
+        // Large single alloc → ObjectAllocationOutsideTLAB
+        sink = new byte[512 * 1024];
+        sink = null;
+    }
+
+    static void allocateSmall(int n) {
+        Object[] arr = new Object[n + 1];
+        for (int i = 0; i <= n; i++) arr[i] = new Object();
+        sink = arr;
+    }
+
+    static void loadClasses() throws Exception {
+        Class.forName("java.util.logging.Logger");
+        Class.forName("java.beans.Introspector");
+        Class.forName("javax.naming.InitialContext");
+    }
+
+    static void monitorContention() throws Exception {
+        synchronized (lock) { lock.wait(1); }
+        ReentrantLock rl = new ReentrantLock();
+        rl.lock();
+        try { /* hold */ } finally { rl.unlock(); }
+    }
+
+    static File tmpFile;
+    static {
+        try { tmpFile = File.createTempFile("jfr_sample", ".tmp"); tmpFile.deleteOnExit(); }
+        catch (IOException e) { tmpFile = null; }
+    }
+
+    static void fileIO() throws Exception {
+        if (tmpFile == null) return;
+        try (FileOutputStream fos = new FileOutputStream(tmpFile, true)) {
+            fos.write(new byte[1024]);
+        }
+        try (FileInputStream fis = new FileInputStream(tmpFile)) {
+            //noinspection ResultOfMethodCallIgnored
+            fis.read(new byte[1024]);
+        }
+    }
+
+    static void fileForce() throws Exception {
+        if (tmpFile == null) return;
+        try (FileChannel ch = FileChannel.open(tmpFile.toPath(),
+                StandardOpenOption.WRITE, StandardOpenOption.APPEND)) {
+            ch.write(java.nio.ByteBuffer.wrap(new byte[64]));
+            ch.force(true);  // → jdk.FileForce
+        }
+    }
+
+    static void socketIO() {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            ss.setSoTimeout(200);
+            int port = ss.getLocalPort();
+            Thread client = new Thread(() -> {
+                try (Socket s = new Socket("127.0.0.1", port)) {
+                    s.getOutputStream().write(new byte[64]);
+                    //noinspection ResultOfMethodCallIgnored
+                    s.getInputStream().read(new byte[64]);
+                } catch (IOException e) { /* ignore */ }
+            });
+            client.setDaemon(true);
+            client.start();
+            try (Socket s = ss.accept()) {
+                //noinspection ResultOfMethodCallIgnored
+                s.getInputStream().read(new byte[64]);
+                s.getOutputStream().write(new byte[64]);
+            }
+            client.join(500);
+        } catch (Exception e) { /* ignore */ }
+    }
+
+    static void httpsRequest() {
+        try {
+            URL url = new URL("https://example.com");
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setConnectTimeout(3000);
+            con.setReadTimeout(3000);
+            con.setRequestMethod("GET");
+            con.getResponseCode();
+            con.disconnect();
+        } catch (Exception e) { /* ignore if no network */ }
+    }
+
+    static void deserialization() {
+        try {
+            // Serialize then deserialize a simple object → jdk.Deserialization
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            try (ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+                oos.writeObject(new ArrayList<>(Arrays.asList("a", "b", "c")));
+            }
+            try (ObjectInputStream ois = new ObjectInputStream(
+                    new ByteArrayInputStream(bos.toByteArray()))) {
+                sink = ois.readObject();
+            }
+        } catch (Exception e) { /* ignore */ }
+    }
+
+    static void triggerThreadDump() {
+        // jdk.ThreadDump is periodic — force a chunk boundary by doing a lot of work
+        for (int i = 0; i < 10; i++) {
+            allocateAndGC();
+            System.gc();
+        }
+    }
+
+    static void throwAndCatch() {
+        for (int i = 0; i < 5; i++) {
+            try {
+                if (i % 2 == 0) throw new RuntimeException("jfr_sample exception " + i);
+            } catch (RuntimeException e) { /* expected */ }
         }
     }
 }

--- a/src/main/java/jfr_sample/Main.java
+++ b/src/main/java/jfr_sample/Main.java
@@ -1,103 +1,499 @@
 package jfr_sample;
 
 import java.io.*;
+import java.lang.instrument.*;
+import java.lang.management.*;
 import java.net.*;
 import java.nio.channels.*;
 import java.nio.file.*;
+import java.security.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.*;
+import java.util.jar.*;
 
 /**
- * Maximalist JFR event generator for GraalVM recordings.
+ * Maximalist JFR event generator.
  * Triggers as many Java-level JFR event types as possible.
+ * Requires: -Djdk.attach.allowAttachSelf=true -XX:DiagnoseSyncOnValueBasedClasses=1
+ *            -XX:NativeMemoryTracking=summary
  */
 public class Main {
 
     static volatile Object sink;
     static final Object lock = new Object();
+    static volatile boolean running = true;
+    static Instrumentation instrumentation;
+
+    // Agent premain — invoked when we self-attach
+    public static void agentmain(String args, Instrumentation inst) {
+        instrumentation = inst;
+    }
+
+    public static void premain(String args, Instrumentation inst) {
+        instrumentation = inst;
+    }
 
     public static void main(String[] args) throws Exception {
-        long end = System.currentTimeMillis() + 20_000;
+        long end = System.currentTimeMillis() + 25_000;
+
+        // Self-attach to get Instrumentation (enables ClassRedefinition/Retransformation)
+        selfAttach();
 
         // ThreadStart/ThreadEnd, ThreadCPULoad, ThreadAllocationStatistics
         ExecutorService pool = Executors.newFixedThreadPool(4);
         for (int t = 0; t < 4; t++) {
             pool.submit(() -> {
-                while (!Thread.currentThread().isInterrupted()) {
+                while (running) {
                     allocateAndGC();
                     try { Thread.sleep(5); } catch (InterruptedException e) { break; }
                 }
             });
         }
 
-        // VirtualThreadStart, VirtualThreadEnd
+        // VirtualThreadStart/End, VirtualThreadPinned (synchronized block in vthread)
+        startVirtualThreads();
+
+        // TLSHandshake, X509Certificate, X509Validation
+        httpsRequest();
+
+        // Deserialization, SerializationMisdeclaration
+        deserialization();
+
+        // ProcessStart
+        startProcess();
+
+        // SecurityPropertyModification
+        Security.setProperty("jdk.disabled.namedCurves", "secp112r1");
+
+        // BooleanFlagChanged, IntFlagChanged, LongFlagChanged, StringFlagChanged,
+        // UnsignedIntFlagChanged, UnsignedLongFlagChanged, DoubleFlagChanged
+        changeDiagnosticFlags();
+
+        // FinalizerStatistics
+        spawnFinalizable();
+
+        // NativeLibraryLoad (already done by JVM — trigger more via System.loadLibrary attempts)
+        triggerNativeLibraryEvents();
+
+        // ClassRedefinition, RedefineClasses, RetransformClasses
+        if (instrumentation != null) {
+            redefineAndRetransform();
+        }
+
+        // ReservedStackActivation (deep recursion + lock)
+        try { deepRecurse(5_000); } catch (Error e) { /* expected: StackOverflowError */ }
+
+        // ThreadDump — trigger via JFR DiagnosticCommand
+        triggerThreadDump();
+
+        // SyncOnValueBasedClass — sync on Integer/Long (value-based with flag enabled)
+        triggerSyncOnValueBased();
+
+        // SerializationMisdeclaration — serialize a class without serialVersionUID
+        serializationMisdeclaration();
+
+        // HeapDump — trigger via HotSpotDiagnostic dumpHeap
+        heapDump();
+
+        // CodeCacheFull — compile many methods with small cache (best-effort)
+        triggerCodeCacheFull();
+
+        while (System.currentTimeMillis() < end) {
+            allocateAndGC();
+            loadClasses();
+            monitorContention();
+            fileIO();
+            fileForce();
+            socketIO();
+            Thread.sleep(2);
+            LockSupport.parkNanos(1_000_000);
+            throwAndCatch();
+            System.gc();
+            // ClassUnload — keep creating class loaders
+            classUnload();
+        }
+
+        running = false;
+        pool.shutdownNow();
+        pool.awaitTermination(2, TimeUnit.SECONDS);
+        // Shutdown event fires on JVM exit
+    }
+
+    // ── Self-attach ──────────────────────────────────────────────────────────
+
+    static void selfAttach() {
+        try {
+            // Build a tiny agent JAR in temp directory
+            Path agentJar = buildAgentJar();
+            // Use VirtualMachine.attach(pid) via reflection (tools.jar / attach API)
+            Class<?> vmClass = null;
+            try {
+                vmClass = Class.forName("com.sun.tools.attach.VirtualMachine");
+            } catch (ClassNotFoundException e) {
+                // Try loading from tools.jar
+                String javaHome = System.getProperty("java.home");
+                File toolsJar = new File(javaHome, "lib/tools.jar");
+                if (!toolsJar.exists()) toolsJar = new File(javaHome, "../lib/tools.jar");
+                if (toolsJar.exists()) {
+                    URLClassLoader cl = new URLClassLoader(new URL[]{toolsJar.toURI().toURL()});
+                    vmClass = cl.loadClass("com.sun.tools.attach.VirtualMachine");
+                }
+            }
+            if (vmClass == null) { System.err.println("[agent] VirtualMachine not available"); return; }
+            String pid = ProcessHandle.current().pid() + "";
+            Object vm = vmClass.getMethod("attach", String.class).invoke(null, pid);
+            vmClass.getMethod("loadAgent", String.class).invoke(vm, agentJar.toString());
+            vmClass.getMethod("detach").invoke(vm);
+            System.out.println("[agent] Self-attached successfully, instrumentation=" + (instrumentation != null));
+        } catch (Exception e) {
+            System.err.println("[agent] Self-attach failed: " + e.getMessage());
+        }
+    }
+
+    static Path buildAgentJar() throws Exception {
+        // Write a tiny MANIFEST and the Main class bytecode into a JAR
+        Path jar = Files.createTempFile("jfr_agent", ".jar");
+        // The agent class is Main itself — just package it as an agent JAR
+        // pointing at jfr_sample.Main as Agent-Class
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        manifest.getMainAttributes().putValue("Agent-Class", "jfr_sample.Main");
+        manifest.getMainAttributes().putValue("Premain-Class", "jfr_sample.Main");
+        manifest.getMainAttributes().putValue("Can-Redefine-Classes", "true");
+        manifest.getMainAttributes().putValue("Can-Retransform-Classes", "true");
+
+        // Find our own class file
+        String className = "jfr_sample/Main.class";
+        URL classUrl = Main.class.getClassLoader().getResource(className);
+
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jar), manifest)) {
+            jos.putNextEntry(new JarEntry(className));
+            if (classUrl != null) {
+                try (InputStream is = classUrl.openStream()) {
+                    is.transferTo(jos);
+                }
+            }
+            jos.closeEntry();
+        }
+        return jar;
+    }
+
+    // ── Flag changes (triggers *FlagChanged events) ──────────────────────────
+
+    static void changeDiagnosticFlags() {
+        try {
+            javax.management.MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+            javax.management.ObjectName on = new javax.management.ObjectName(
+                    "com.sun.management:type=HotSpotDiagnostic");
+            // BooleanFlagChanged: toggle a manageable bool flag
+            mbs.invoke(on, "setVMOption", new Object[]{"PrintConcurrentLocks", "true"},
+                    new String[]{"java.lang.String", "java.lang.String"});
+            mbs.invoke(on, "setVMOption", new Object[]{"PrintConcurrentLocks", "false"},
+                    new String[]{"java.lang.String", "java.lang.String"});
+            // UnsignedLongFlagChanged (uintx on 64-bit): tweak heap ratios
+            mbs.invoke(on, "setVMOption", new Object[]{"MinHeapFreeRatio", "45"},
+                    new String[]{"java.lang.String", "java.lang.String"});
+            mbs.invoke(on, "setVMOption", new Object[]{"MinHeapFreeRatio", "40"},
+                    new String[]{"java.lang.String", "java.lang.String"});
+            mbs.invoke(on, "setVMOption", new Object[]{"MaxHeapFreeRatio", "75"},
+                    new String[]{"java.lang.String", "java.lang.String"});
+            mbs.invoke(on, "setVMOption", new Object[]{"MaxHeapFreeRatio", "70"},
+                    new String[]{"java.lang.String", "java.lang.String"});
+            // StringFlagChanged: HeapDumpPath
+            mbs.invoke(on, "setVMOption", new Object[]{"HeapDumpPath", "/tmp/jfr_heap"},
+                    new String[]{"java.lang.String", "java.lang.String"});
+            // DoubleFlagChanged: G1PeriodicGCSystemLoadThreshold
+            mbs.invoke(on, "setVMOption", new Object[]{"G1PeriodicGCSystemLoadThreshold", "0.5"},
+                    new String[]{"java.lang.String", "java.lang.String"});
+            mbs.invoke(on, "setVMOption", new Object[]{"G1PeriodicGCSystemLoadThreshold", "0.0"},
+                    new String[]{"java.lang.String", "java.lang.String"});
+            // IntFlagChanged: HeapDumpGzipLevel (int)
+            mbs.invoke(on, "setVMOption", new Object[]{"HeapDumpGzipLevel", "1"},
+                    new String[]{"java.lang.String", "java.lang.String"});
+            mbs.invoke(on, "setVMOption", new Object[]{"HeapDumpGzipLevel", "0"},
+                    new String[]{"java.lang.String", "java.lang.String"});
+            // UnsignedIntFlagChanged: FullGCHeapDumpLimit (uint)
+            mbs.invoke(on, "setVMOption", new Object[]{"FullGCHeapDumpLimit", "1"},
+                    new String[]{"java.lang.String", "java.lang.String"});
+            mbs.invoke(on, "setVMOption", new Object[]{"FullGCHeapDumpLimit", "0"},
+                    new String[]{"java.lang.String", "java.lang.String"});
+            // LongFlagChanged: SoftMaxHeapSize (size_t)
+            long currentMax = Runtime.getRuntime().maxMemory();
+            mbs.invoke(on, "setVMOption", new Object[]{"SoftMaxHeapSize", String.valueOf(currentMax / 2)},
+                    new String[]{"java.lang.String", "java.lang.String"});
+            mbs.invoke(on, "setVMOption", new Object[]{"SoftMaxHeapSize", String.valueOf(currentMax)},
+                    new String[]{"java.lang.String", "java.lang.String"});
+            System.out.println("[flags] changeDiagnosticFlags done");
+        } catch (Exception e) {
+            System.err.println("[flags] changeDiagnosticFlags failed: " + e.getMessage());
+        }
+    }
+
+    // ── ProcessStart ─────────────────────────────────────────────────────────
+
+    static void startProcess() {
+        try {
+            Process p = new ProcessBuilder("java", "-version")
+                    .redirectErrorStream(true).start();
+            p.waitFor(3, TimeUnit.SECONDS);
+        } catch (Exception e) { /* ignore */ }
+    }
+
+    // ── RedefineClasses / RetransformClasses ─────────────────────────────────
+
+    static void redefineAndRetransform() {
+        try {
+            // Retransform: no-op transformer, fires RetransformClasses
+            ClassFileTransformer noop = new ClassFileTransformer() {
+                @Override public byte[] transform(ClassLoader l, String n, Class<?> c,
+                        ProtectionDomain pd, byte[] buf) { return null; }
+            };
+            instrumentation.addTransformer(noop, true);
+            instrumentation.retransformClasses(java.util.ArrayList.class);
+            instrumentation.removeTransformer(noop);
+
+            // Redefine: replace ArrayList with identical bytes, fires RedefineClasses + ClassRedefinition
+            String res = "java/util/ArrayList.class";
+            try (InputStream is = ClassLoader.getSystemResourceAsStream(res)) {
+                if (is != null) {
+                    byte[] bytes = is.readAllBytes();
+                    ClassDefinition def = new ClassDefinition(java.util.ArrayList.class, bytes);
+                    instrumentation.redefineClasses(def);
+                    System.out.println("[redef] RedefineClasses done");
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("[redef] failed: " + e.getMessage());
+        }
+    }
+
+    // ── ThreadDump via JFR DiagnosticCommand ─────────────────────────────────
+
+    static void triggerThreadDump() {
+        // jdk.ThreadDump fires periodically — also trigger via JFR diagnostic command
+        try {
+            javax.management.MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+            javax.management.ObjectName on = new javax.management.ObjectName(
+                    "com.sun.management:type=DiagnosticCommand");
+            mbs.invoke(on, "threadPrint", new Object[]{new String[0]}, new String[]{"[Ljava.lang.String;"});
+            System.out.println("[tdump] ThreadDump triggered via DiagnosticCommand");
+        } catch (Exception e) {
+            // Fallback: use ThreadMXBean
+            ThreadMXBean tmx = ManagementFactory.getThreadMXBean();
+            sink = tmx.dumpAllThreads(true, true);
+            System.out.println("[tdump] ThreadDump via ThreadMXBean (fallback)");
+        }
+    }
+
+    // ── SyncOnValueBasedClass ─────────────────────────────────────────────────
+
+    @SuppressWarnings("synchronization")
+    static void triggerSyncOnValueBased() {
+        // With -XX:DiagnoseSyncOnValueBasedClasses=1, syncing on Integer fires the event
+        Integer boxed = Integer.valueOf(42);
+        for (int i = 0; i < 10; i++) {
+            synchronized (boxed) { sink = boxed; }
+        }
+        Long boxedL = Long.valueOf(123L);
+        for (int i = 0; i < 10; i++) {
+            synchronized (boxedL) { sink = boxedL; }
+        }
+        System.out.println("[sync] triggerSyncOnValueBased done");
+    }
+
+    // ── ClassUnload ───────────────────────────────────────────────────────────
+
+    static void classUnload() throws Exception {
+        // Load a trivial class in a child classloader and let it GC
+        ClassLoader cl = new ClassLoader(null) {
+            @Override protected Class<?> findClass(String name) throws ClassNotFoundException {
+                byte[] bytes = makeTrivialClass(name);
+                if (bytes == null) throw new ClassNotFoundException(name);
+                return defineClass(name, bytes, 0, bytes.length);
+            }
+        };
+        try {
+            String name = "jfr_sample.Unloadable" + System.nanoTime();
+            cl.loadClass(name);
+        } catch (ClassNotFoundException e) { /* ok */ }
+        sink = null;
+        System.gc();
+    }
+
+    /** Generate minimal valid class file bytes for a class with given binary name, JDK 8 (52.0). */
+    static byte[] makeTrivialClass(String binaryName) {
+        // Minimal class: version 52 (Java 8), one constant pool entry for class name,
+        // public, extends java/lang/Object, no fields, no methods, no attributes
+        String internalName = binaryName.replace('.', '/');
+        // Constant pool:
+        //  #1 = Utf8  <internalName>
+        //  #2 = Class #1
+        //  #3 = Utf8  "java/lang/Object"
+        //  #4 = Class #3
+        //  #5 = Utf8  "Code"   -- not strictly needed for empty class
+        byte[] nameBytes = internalName.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        byte[] objBytes = "java/lang/Object".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+        java.io.DataOutputStream dos = new java.io.DataOutputStream(bos);
+        try {
+            dos.writeInt(0xCAFEBABE);      // magic
+            dos.writeShort(0);             // minor version
+            dos.writeShort(52);            // major version (Java 8)
+            dos.writeShort(5);             // constant pool count (entries #1..#4)
+            // #1 Utf8 internalName
+            dos.writeByte(1); dos.writeShort(nameBytes.length); dos.write(nameBytes);
+            // #2 Class -> #1
+            dos.writeByte(7); dos.writeShort(1);
+            // #3 Utf8 "java/lang/Object"
+            dos.writeByte(1); dos.writeShort(objBytes.length); dos.write(objBytes);
+            // #4 Class -> #3
+            dos.writeByte(7); dos.writeShort(3);
+            dos.writeShort(0x0021);        // access flags: ACC_PUBLIC | ACC_SUPER
+            dos.writeShort(2);             // this class (#2)
+            dos.writeShort(4);             // super class (#4)
+            dos.writeShort(0);             // interfaces count
+            dos.writeShort(0);             // fields count
+            dos.writeShort(0);             // methods count
+            dos.writeShort(0);             // attributes count
+            dos.flush();
+        } catch (IOException e) { return null; }
+        return bos.toByteArray();
+    }
+
+    // ── FinalizerStatistics ───────────────────────────────────────────────────
+
+    static void spawnFinalizable() {
+        for (int i = 0; i < 200; i++) {
+            sink = new Object() {
+                @Override @SuppressWarnings("deprecation")
+                protected void finalize() { /* trigger finalizer queue */ }
+            };
+        }
+        sink = null;
+        System.gc();
+        System.runFinalization();
+    }
+
+    // ── NativeLibraryLoad/Unload ──────────────────────────────────────────────
+
+    static void triggerNativeLibraryEvents() {
+        // Loading a library that's already loaded is a no-op but the JFR events
+        // fire on first load — try some that may not be loaded yet
+        String[] libs = { "java", "net", "nio", "zip" };
+        for (String lib : libs) {
+            try { System.loadLibrary(lib); } catch (UnsatisfiedLinkError e) { /* already loaded or not found */ }
+        }
+    }
+
+    // ── VirtualThreadPinned ───────────────────────────────────────────────────
+
+    static void startVirtualThreads() throws Exception {
         try {
             ExecutorService vPool = (ExecutorService)
                 Executors.class.getMethod("newVirtualThreadPerTaskExecutor").invoke(null);
-            for (int i = 0; i < 20; i++) {
+
+            // VirtualThreadPinned: synchronized block + blocking op from a virtual thread
+            for (int i = 0; i < 10; i++) {
                 final int n = i;
                 vPool.submit(() -> {
-                    try { Thread.sleep(1); } catch (InterruptedException e) {}
-                    allocateSmall(n);
+                    try {
+                        // Pinned: synchronized + sleep triggers jdk.VirtualThreadPinned
+                        synchronized (lock) { Thread.sleep(5); }
+                        allocateSmall(n);
+                    } catch (InterruptedException e) { /* ok */ }
                 });
             }
             vPool.shutdown();
             vPool.awaitTermination(5, TimeUnit.SECONDS);
+            System.out.println("[vthread] Virtual thread tasks done");
         } catch (NoSuchMethodException e) { /* JDK < 21 */ }
-
-        // ThreadDump (trigger once at start)
-        triggerThreadDump();
-
-        // TLSHandshake, X509Certificate, X509Validation (HTTPS)
-        httpsRequest();
-
-        // NativeMemoryUsage (requires NMT — best-effort, may be 0 without flag)
-        // Deserialization
-        deserialization();
-
-        while (System.currentTimeMillis() < end) {
-            // GarbageCollection, GCHeapSummary, G1*, ObjectAllocation*, Promote*
-            allocateAndGC();
-
-            // ClassLoad, ClassDefine
-            loadClasses();
-
-            // JavaMonitorEnter, JavaMonitorWait, JavaMonitorInflate, JavaMonitorNotify
-            monitorContention();
-
-            // FileRead, FileWrite
-            fileIO();
-
-            // FileForce (FileChannel.force)
-            fileForce();
-
-            // SocketRead, SocketWrite
-            socketIO();
-
-            // ThreadSleep
-            Thread.sleep(2);
-
-            // ThreadPark
-            LockSupport.parkNanos(1_000_000);
-
-            // JavaExceptionThrow
-            throwAndCatch();
-
-            // SystemGC → GarbageCollection, GCHeapSummary
-            System.gc();
-        }
-
-        pool.shutdownNow();
-        pool.awaitTermination(2, TimeUnit.SECONDS);
     }
+
+    // ── ReservedStackActivation ───────────────────────────────────────────────
+
+    static final ReentrantLock deepLock = new ReentrantLock();
+
+    // ReentrantLock methods use @ReservedStackAccess internally.
+    // By calling lock() deep in a recursion, we trigger ReservedStackActivation.
+    static void deepRecurse(int n) {
+        if (n <= 0) {
+            deepLock.lock();
+            try { sink = Thread.currentThread().getName(); } finally { deepLock.unlock(); }
+            return;
+        }
+        deepRecurse(n - 1);
+    }
+
+    // ── CodeCacheFull ─────────────────────────────────────────────────────────
+
+    static void triggerCodeCacheFull() {
+        // With -XX:ReservedCodeCacheSize=32m, aggressively JIT-compiling many hot methods
+        // may fill the code cache and trigger jdk.CodeCacheFull
+        // We generate many large methods to stress the JIT compiler
+        try {
+            for (int pass = 0; pass < 3; pass++) {
+                for (int outer = 0; outer < 300; outer++) {
+                    sink = hotMethod1(outer) + hotMethod2(outer) + hotMethod3(outer)
+                         + hotMethod4(outer) + hotMethod5(outer) + hotMethod6(outer)
+                         + hotMethod7(outer) + hotMethod8(outer);
+                }
+            }
+        } catch (Exception e) { /* ignore */ }
+    }
+
+    static int hotMethod1(int n) { int r = 0; for (int i = 0; i < 500; i++) r += i * n + Math.abs(i - n); return r; }
+    static int hotMethod2(int n) { int r = 0; for (int i = 0; i < 500; i++) r += (i ^ n) + Integer.bitCount(i); return r; }
+    static int hotMethod3(int n) { int r = 0; for (int i = 0; i < 500; i++) r += Integer.reverse(i) + n; return r; }
+    static int hotMethod4(int n) { double r = 0; for (int i = 1; i < 300; i++) r += Math.log(i) * n; return (int) r; }
+    static int hotMethod5(int n) { double r = 0; for (int i = 1; i < 300; i++) r += Math.sqrt(i) + n; return (int) r; }
+    static int hotMethod6(int n) { long r = 0; for (int i = 0; i < 500; i++) r += Long.reverseBytes(i * (long)n); return (int) r; }
+    static int hotMethod7(int n) { int r = 0; for (int i = 0; i < 500; i++) r += Integer.numberOfLeadingZeros(i + n) * i; return r; }
+    static int hotMethod8(int n) { double r = 1.0; for (int i = 1; i < 300; i++) r = Math.fma(r, Math.cos(i), n); return (int) r; }
+
+
+
+    static void serializationMisdeclaration() {
+        // Serializing a class that doesn't declare serialVersionUID triggers the event
+        // (requires jdk.SerializationMisdeclaration enabled in JFC)
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            try (ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+                // Use an anonymous class with no serialVersionUID
+                oos.writeObject(new java.io.Serializable() {
+                    String data = "misdeclaration_test";
+                });
+            }
+        } catch (Exception e) { /* ignore */ }
+    }
+
+    // ── HeapDump ──────────────────────────────────────────────────────────────
+
+    static void heapDump() {
+        try {
+            javax.management.MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+            javax.management.ObjectName on = new javax.management.ObjectName(
+                    "com.sun.management:type=HotSpotDiagnostic");
+            String path = "/tmp/jfr_sample_heap_" + System.nanoTime() + ".hprof";
+            mbs.invoke(on, "dumpHeap", new Object[]{path, Boolean.TRUE},
+                    new String[]{"java.lang.String", "boolean"});
+            new File(path).delete();
+            System.out.println("[heap] HeapDump done");
+        } catch (Exception e) {
+            System.err.println("[heap] HeapDump failed: " + e.getMessage());
+        }
+    }
+
+    // ── ThreadDump (old stub, removed) ───────────────────────────────────────
+
+
+    // ── Core helpers ──────────────────────────────────────────────────────────
 
     static void allocateAndGC() {
         List<byte[]> list = new ArrayList<>(500);
         for (int i = 0; i < 500; i++) list.add(new byte[4096]);
         sink = list;
-        // Large single alloc → ObjectAllocationOutsideTLAB
-        sink = new byte[512 * 1024];
+        sink = new byte[512 * 1024];  // OutsideTLAB
         sink = null;
     }
 
@@ -128,13 +524,8 @@ public class Main {
 
     static void fileIO() throws Exception {
         if (tmpFile == null) return;
-        try (FileOutputStream fos = new FileOutputStream(tmpFile, true)) {
-            fos.write(new byte[1024]);
-        }
-        try (FileInputStream fis = new FileInputStream(tmpFile)) {
-            //noinspection ResultOfMethodCallIgnored
-            fis.read(new byte[1024]);
-        }
+        try (FileOutputStream fos = new FileOutputStream(tmpFile, true)) { fos.write(new byte[1024]); }
+        try (FileInputStream fis = new FileInputStream(tmpFile)) { fis.read(new byte[1024]); }
     }
 
     static void fileForce() throws Exception {
@@ -142,7 +533,7 @@ public class Main {
         try (FileChannel ch = FileChannel.open(tmpFile.toPath(),
                 StandardOpenOption.WRITE, StandardOpenOption.APPEND)) {
             ch.write(java.nio.ByteBuffer.wrap(new byte[64]));
-            ch.force(true);  // → jdk.FileForce
+            ch.force(true);
         }
     }
 
@@ -153,14 +544,11 @@ public class Main {
             Thread client = new Thread(() -> {
                 try (Socket s = new Socket("127.0.0.1", port)) {
                     s.getOutputStream().write(new byte[64]);
-                    //noinspection ResultOfMethodCallIgnored
                     s.getInputStream().read(new byte[64]);
                 } catch (IOException e) { /* ignore */ }
             });
-            client.setDaemon(true);
-            client.start();
+            client.setDaemon(true); client.start();
             try (Socket s = ss.accept()) {
-                //noinspection ResultOfMethodCallIgnored
                 s.getInputStream().read(new byte[64]);
                 s.getOutputStream().write(new byte[64]);
             }
@@ -172,8 +560,7 @@ public class Main {
         try {
             URL url = new URL("https://example.com");
             HttpURLConnection con = (HttpURLConnection) url.openConnection();
-            con.setConnectTimeout(3000);
-            con.setReadTimeout(3000);
+            con.setConnectTimeout(3000); con.setReadTimeout(3000);
             con.setRequestMethod("GET");
             con.getResponseCode();
             con.disconnect();
@@ -182,30 +569,20 @@ public class Main {
 
     static void deserialization() {
         try {
-            // Serialize then deserialize a simple object → jdk.Deserialization
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             try (ObjectOutputStream oos = new ObjectOutputStream(bos)) {
                 oos.writeObject(new ArrayList<>(Arrays.asList("a", "b", "c")));
             }
-            try (ObjectInputStream ois = new ObjectInputStream(
-                    new ByteArrayInputStream(bos.toByteArray()))) {
+            try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bos.toByteArray()))) {
                 sink = ois.readObject();
             }
         } catch (Exception e) { /* ignore */ }
     }
 
-    static void triggerThreadDump() {
-        // jdk.ThreadDump is periodic — force a chunk boundary by doing a lot of work
-        for (int i = 0; i < 10; i++) {
-            allocateAndGC();
-            System.gc();
-        }
-    }
-
     static void throwAndCatch() {
         for (int i = 0; i < 5; i++) {
             try {
-                if (i % 2 == 0) throw new RuntimeException("jfr_sample exception " + i);
+                if (i % 2 == 0) throw new RuntimeException("jfr_sample " + i);
             } catch (RuntimeException e) { /* expected */ }
         }
     }

--- a/src/main/kotlin/me/bechberger/collector/ExampleAdder.kt
+++ b/src/main/kotlin/me/bechberger/collector/ExampleAdder.kt
@@ -15,12 +15,12 @@ import kotlin.io.path.writeText
 /** Adds examples to the events and types */
 class ExampleAdder(val metadata: me.bechberger.collector.xml.Metadata) {
 
-    fun addEventsFromFile(label: String, description: String, file: Path) {
+    fun addEventsFromFile(label: String, description: String, file: Path, platform: String? = null) {
         assert(metadata.exampleFiles.none { it.label == label || it.description == description })
         val processor = Processor(file)
         processor.process()
         val id = metadata.exampleFiles.size
-        metadata.exampleFiles.add(me.bechberger.collector.xml.ExampleFile(label, description))
+        metadata.exampleFiles.add(me.bechberger.collector.xml.ExampleFile(label, description, platform))
         addEventExamples(id, processor)
     }
 
@@ -197,9 +197,20 @@ class ExampleAdder(val metadata: me.bechberger.collector.xml.Metadata) {
 }
 
 fun main(args: Array<String>) {
-    if (args.size < 4 || (args.size - 2) % 3 != 0) {
+    // Optional second argument: --platform=<value> applies to all examples in this call
+    val platform: String?
+    val startIdx: Int
+    if (args.size > 1 && args[1].startsWith("--platform=")) {
+        platform = args[1].removePrefix("--platform=")
+        startIdx = 2
+    } else {
+        platform = null
+        startIdx = 1
+    }
+    val tripletArgs = args.size - startIdx - 1  // subtract metadata path and output path
+    if (args.size < 4 || tripletArgs % 3 != 0) {
         println(
-            "Usage: ExampleAdder <path to metadata.xml> <label of file> <description of file> <JFR file> ... " + "<path to resulting metadata.xml>"
+            "Usage: ExampleAdder <path to metadata.xml> [--platform=<value>] <label of file> <description of file> <JFR file> ... " + "<path to resulting metadata.xml>"
         )
         return
     }
@@ -207,14 +218,14 @@ fun main(args: Array<String>) {
     val metadata = metadataPath.readXmlAs(me.bechberger.collector.xml.Metadata::class.java)
     println("Read metadata from $metadataPath: ${metadata.events.size} events, ${metadata.types.size} types")
     val eventAdder = ExampleAdder(metadata)
-    for (i in 1 until args.size step 3) {
+    for (i in startIdx until args.size step 3) {
         if (args.size - i < 3) {
             break
         }
         val label = args[i]
         val description = args[i + 1]
         val file = Paths.get(args[i + 2])
-        eventAdder.addEventsFromFile(label, description, file)
+        eventAdder.addEventsFromFile(label, description, file, platform)
     }
     val out = args[args.size - 1]
     if (out == "-") {

--- a/src/main/kotlin/me/bechberger/collector/ExampleAdder.kt
+++ b/src/main/kotlin/me/bechberger/collector/ExampleAdder.kt
@@ -16,12 +16,19 @@ import kotlin.io.path.writeText
 class ExampleAdder(val metadata: me.bechberger.collector.xml.Metadata) {
 
     fun addEventsFromFile(label: String, description: String, file: Path, platform: String? = null) {
+        addEventsFromFiles(label, description, listOf(file), platform)
+    }
+
+    fun addEventsFromFiles(label: String, description: String, files: List<Path>, platform: String? = null) {
         assert(metadata.exampleFiles.none { it.label == label || it.description == description })
-        val processor = Processor(file)
-        processor.process()
         val id = metadata.exampleFiles.size
         metadata.exampleFiles.add(me.bechberger.collector.xml.ExampleFile(label, description, platform))
-        addEventExamples(id, processor)
+        for (file in files) {
+            if (!file.toFile().exists()) continue
+            val processor = Processor(file)
+            processor.process()
+            addEventExamples(id, processor)
+        }
     }
 
     private fun addEventExamples(id: Int, processor: Processor) {
@@ -224,8 +231,9 @@ fun main(args: Array<String>) {
         }
         val label = args[i]
         val description = args[i + 1]
-        val file = Paths.get(args[i + 2])
-        eventAdder.addEventsFromFile(label, description, file, platform)
+        // Support multiple comma-separated JFR files for the same label
+        val files = args[i + 2].split(",").map { Paths.get(it.trim()) }
+        eventAdder.addEventsFromFiles(label, description, files, platform)
     }
     val out = args[args.size - 1]
     if (out == "-") {

--- a/src/main/kotlin/me/bechberger/collector/MarkJavaLevelGraalEvents.kt
+++ b/src/main/kotlin/me/bechberger/collector/MarkJavaLevelGraalEvents.kt
@@ -1,0 +1,39 @@
+package me.bechberger.collector
+
+import me.bechberger.collector.xml.Metadata
+import me.bechberger.collector.xml.readXmlAs
+import java.nio.file.Paths
+import kotlin.io.path.writeText
+import kotlin.system.exitProcess
+
+/**
+ * Marks Java-level JDK JFR events supported by GraalVM Native Image "for free" — i.e. events
+ * not listed in JfrEvent.java but inherited through the JDK event infrastructure.
+ *
+ * Called by releaser.py after GraalEventAdder processes the VM-level events.
+ *
+ * Usage: <metadata.xml> <EventName1> <EventName2> ... <result.xml>
+ * The result path may equal the input path for an in-place update.
+ */
+fun main(args: Array<String>) {
+    if (args.size < 3) {
+        println("Usage: MarkJavaLevelGraalEvents <path to metadata.xml> <event1> ... <path to result xml file>")
+        exitProcess(1)
+    }
+    val metadataPath = Paths.get(args[0])
+    val outPath = Paths.get(args[args.size - 1])
+    val eventNames = args.drop(1).dropLast(1)
+    val metadata = metadataPath.readXmlAs(Metadata::class.java)
+    var marked = 0
+    for (name in eventNames) {
+        val event = metadata.getEvent(name)
+        if (event != null) {
+            event.includedInGraal()
+            marked++
+        } else {
+            println("Java-level Graal event '$name' not found in metadata — skipping")
+        }
+    }
+    println("Marked $marked/${eventNames.size} Java-level events as supported by GraalVM Native Image")
+    outPath.writeText(metadata.toString())
+}

--- a/src/main/kotlin/me/bechberger/collector/xml/Metadata.kt
+++ b/src/main/kotlin/me/bechberger/collector/xml/Metadata.kt
@@ -538,12 +538,16 @@ class ExampleFile() {
     @JacksonXmlProperty(isAttribute = true)
     lateinit var label: String
 
+    @JacksonXmlProperty(isAttribute = true)
+    var platform: String? = null
+
     @JacksonXmlText
     lateinit var description: String
 
-    constructor(label: String, description: String) : this() {
+    constructor(label: String, description: String, platform: String? = null) : this() {
         this.label = label
         this.description = description
+        this.platform = platform
     }
 }
 

--- a/website/src/main/kotlin/me/bechberger/collector/site/Main.kt
+++ b/website/src/main/kotlin/me/bechberger/collector/site/Main.kt
@@ -268,9 +268,6 @@ class Main(
         val period: String?,
         val inGraal: Boolean,
         val inGraalOnly: Boolean,
-        val notOnLinux: Boolean = false,
-        val notOnMacos: Boolean = false,
-        val notOnWindows: Boolean = false,
     )
 
     data class TypeDescriptorScope(val name: String, val description: String? = null, val link: String? = null)
@@ -796,21 +793,6 @@ class Main(
                 },
                 inGraal = event.isInJDKAndGraal() || event.isGraalOnly(),
                 inGraalOnly = event.isGraalOnly(),
-                notOnLinux = run {
-                    val knownPlatforms = metadata.exampleFiles.mapNotNull { it.platform }.toSet()
-                    val appearedOn = event.appearedIn.mapNotNull { metadata.exampleFiles[it].platform }.toSet()
-                    knownPlatforms.size > 1 && "linux" in knownPlatforms && "linux" !in appearedOn
-                },
-                notOnMacos = run {
-                    val knownPlatforms = metadata.exampleFiles.mapNotNull { it.platform }.toSet()
-                    val appearedOn = event.appearedIn.mapNotNull { metadata.exampleFiles[it].platform }.toSet()
-                    knownPlatforms.size > 1 && "macos" in knownPlatforms && "macos" !in appearedOn
-                },
-                notOnWindows = run {
-                    val knownPlatforms = metadata.exampleFiles.mapNotNull { it.platform }.toSet()
-                    val appearedOn = event.appearedIn.mapNotNull { metadata.exampleFiles[it].platform }.toSet()
-                    knownPlatforms.size > 1 && "windows" in knownPlatforms && "windows" !in appearedOn
-                },
             ),
             source = event.source,
             configurations = createConfigurationScope(metadata, event),

--- a/website/src/main/kotlin/me/bechberger/collector/site/Main.kt
+++ b/website/src/main/kotlin/me/bechberger/collector/site/Main.kt
@@ -267,7 +267,10 @@ class Main(
         val hasThread: Boolean,
         val period: String?,
         val inGraal: Boolean,
-        val inGraalOnly: Boolean
+        val inGraalOnly: Boolean,
+        val linuxOnly: Boolean = false,
+        val macosOnly: Boolean = false,
+        val windowsOnly: Boolean = false,
     )
 
     data class TypeDescriptorScope(val name: String, val description: String? = null, val link: String? = null)
@@ -449,7 +452,7 @@ class Main(
         )
     }
 
-    data class ExampleScope(val name: String, val content: String = "")
+    data class ExampleScope(val name: String, val content: String = "", val platform: String? = null)
 
     data class ExamplesScope(val id: String, val examples: DecoratedCollection<ExampleScope>)
 
@@ -543,7 +546,8 @@ class Main(
         metadata: Metadata,
         example: Example,
     ): ExampleScope {
-        return ExampleScope(metadata.getExampleName(example.exampleFile), formatExample(metadata, example))
+        val file = metadata.exampleFiles[example.exampleFile]
+        return ExampleScope(file.label, formatExample(metadata, example), file.platform)
     }
 
     data class EventScope(
@@ -792,6 +796,18 @@ class Main(
                 },
                 inGraal = event.isInJDKAndGraal() || event.isGraalOnly(),
                 inGraalOnly = event.isGraalOnly(),
+                linuxOnly = run {
+                    val platforms = event.appearedIn.mapNotNull { metadata.exampleFiles[it].platform }.toSet()
+                    platforms.isNotEmpty() && platforms == setOf("linux")
+                },
+                macosOnly = run {
+                    val platforms = event.appearedIn.mapNotNull { metadata.exampleFiles[it].platform }.toSet()
+                    platforms.isNotEmpty() && platforms == setOf("macos")
+                },
+                windowsOnly = run {
+                    val platforms = event.appearedIn.mapNotNull { metadata.exampleFiles[it].platform }.toSet()
+                    platforms.isNotEmpty() && platforms == setOf("windows")
+                },
             ),
             source = event.source,
             configurations = createConfigurationScope(metadata, event),

--- a/website/src/main/kotlin/me/bechberger/collector/site/Main.kt
+++ b/website/src/main/kotlin/me/bechberger/collector/site/Main.kt
@@ -268,9 +268,9 @@ class Main(
         val period: String?,
         val inGraal: Boolean,
         val inGraalOnly: Boolean,
-        val linuxOnly: Boolean = false,
-        val macosOnly: Boolean = false,
-        val windowsOnly: Boolean = false,
+        val notOnLinux: Boolean = false,
+        val notOnMacos: Boolean = false,
+        val notOnWindows: Boolean = false,
     )
 
     data class TypeDescriptorScope(val name: String, val description: String? = null, val link: String? = null)
@@ -796,17 +796,20 @@ class Main(
                 },
                 inGraal = event.isInJDKAndGraal() || event.isGraalOnly(),
                 inGraalOnly = event.isGraalOnly(),
-                linuxOnly = run {
-                    val platforms = event.appearedIn.mapNotNull { metadata.exampleFiles[it].platform }.toSet()
-                    platforms.isNotEmpty() && platforms == setOf("linux")
+                notOnLinux = run {
+                    val knownPlatforms = metadata.exampleFiles.mapNotNull { it.platform }.toSet()
+                    val appearedOn = event.appearedIn.mapNotNull { metadata.exampleFiles[it].platform }.toSet()
+                    knownPlatforms.size > 1 && "linux" in knownPlatforms && "linux" !in appearedOn
                 },
-                macosOnly = run {
-                    val platforms = event.appearedIn.mapNotNull { metadata.exampleFiles[it].platform }.toSet()
-                    platforms.isNotEmpty() && platforms == setOf("macos")
+                notOnMacos = run {
+                    val knownPlatforms = metadata.exampleFiles.mapNotNull { it.platform }.toSet()
+                    val appearedOn = event.appearedIn.mapNotNull { metadata.exampleFiles[it].platform }.toSet()
+                    knownPlatforms.size > 1 && "macos" in knownPlatforms && "macos" !in appearedOn
                 },
-                windowsOnly = run {
-                    val platforms = event.appearedIn.mapNotNull { metadata.exampleFiles[it].platform }.toSet()
-                    platforms.isNotEmpty() && platforms == setOf("windows")
+                notOnWindows = run {
+                    val knownPlatforms = metadata.exampleFiles.mapNotNull { it.platform }.toSet()
+                    val appearedOn = event.appearedIn.mapNotNull { metadata.exampleFiles[it].platform }.toSet()
+                    knownPlatforms.size > 1 && "windows" in knownPlatforms && "windows" !in appearedOn
                 },
             ),
             source = event.source,

--- a/website/src/main/resources/template/event.html
+++ b/website/src/main/resources/template/event.html
@@ -44,15 +44,15 @@
     <span class="badge bg-success graal-badge">graal vm</span>
   {{/inGraal}}
   {{/inGraalOnly}}
-  {{#linuxOnly}}
-    <span class="badge bg-secondary platform-badge" title="Only observed on Linux">Linux only</span>
-  {{/linuxOnly}}
-  {{#macosOnly}}
-    <span class="badge bg-secondary platform-badge" title="Only observed on macOS">macOS only</span>
-  {{/macosOnly}}
-  {{#windowsOnly}}
-    <span class="badge bg-secondary platform-badge" title="Only observed on Windows">Windows only</span>
-  {{/windowsOnly}}
+  {{#notOnLinux}}
+    <span class="badge bg-secondary platform-badge" title="Not observed on Linux in any recording">not on Linux</span>
+  {{/notOnLinux}}
+  {{#notOnMacos}}
+    <span class="badge bg-secondary platform-badge" title="Not observed on macOS in any recording">not on macOS</span>
+  {{/notOnMacos}}
+  {{#notOnWindows}}
+    <span class="badge bg-secondary platform-badge" title="Not observed on Windows in any recording">not on Windows</span>
+  {{/notOnWindows}}
   {{/flags}}
 </p>
 {{#source}}

--- a/website/src/main/resources/template/event.html
+++ b/website/src/main/resources/template/event.html
@@ -44,15 +44,6 @@
     <span class="badge bg-success graal-badge">graal vm</span>
   {{/inGraal}}
   {{/inGraalOnly}}
-  {{#notOnLinux}}
-    <span class="badge bg-secondary platform-badge" title="Not observed on Linux in any recording">not on Linux</span>
-  {{/notOnLinux}}
-  {{#notOnMacos}}
-    <span class="badge bg-secondary platform-badge" title="Not observed on macOS in any recording">not on macOS</span>
-  {{/notOnMacos}}
-  {{#notOnWindows}}
-    <span class="badge bg-secondary platform-badge" title="Not observed on Windows in any recording">not on Windows</span>
-  {{/notOnWindows}}
   {{/flags}}
 </p>
 {{#source}}

--- a/website/src/main/resources/template/event.html
+++ b/website/src/main/resources/template/event.html
@@ -44,6 +44,15 @@
     <span class="badge bg-success graal-badge">graal vm</span>
   {{/inGraal}}
   {{/inGraalOnly}}
+  {{#linuxOnly}}
+    <span class="badge bg-secondary platform-badge" title="Only observed on Linux">Linux only</span>
+  {{/linuxOnly}}
+  {{#macosOnly}}
+    <span class="badge bg-secondary platform-badge" title="Only observed on macOS">macOS only</span>
+  {{/macosOnly}}
+  {{#windowsOnly}}
+    <span class="badge bg-secondary platform-badge" title="Only observed on Windows">Windows only</span>
+  {{/windowsOnly}}
   {{/flags}}
 </p>
 {{#source}}

--- a/website/src/main/resources/template/examples.html
+++ b/website/src/main/resources/template/examples.html
@@ -4,7 +4,7 @@
             <li class="nav-item" role="presentation">
                 <a class="nav-link {{#first}}active{{/first}}" id="{{id}}-tab"
                 data-bs-toggle="tab" href="#{{id}}{{index}}" role="tab"
-                aria-controls="{{id}}{{index}}" aria-selected="true">{{value.name}}</a>
+                aria-controls="{{id}}{{index}}" aria-selected="true">{{value.name}}{{#value.platform}} <span class="badge bg-secondary example-platform-badge">{{.}}</span>{{/value.platform}}</a>
             </li>
         {{/examples}}
     </ul>


### PR DESCRIPTION
## Summary

- **Issue #7**: Java-level JDK JFR events (e.g. `ThreadSleep`, `VirtualThreadStart`, `ActiveRecording`) are now marked as `JDK_AND_GRAAL` by fetching the canonical supported-events list from `oracle/graal` JFR.md (cached weekly). New `MarkJavaLevelGraalEventsKt` Kotlin entry point applies `includedInGraal()` as a second pass after the existing `GraalEventAdder`.
- **Issue #2**: JFR sample collection now runs on `ubuntu-latest`, `macos-latest`, and `windows-latest` via an OS matrix on the `create-jfr` job. Files are named `sample_{platform}_{gc}.jfr`; `ExampleFile` gains a `platform` XML attribute; labels and descriptions include the OS name.

Closes #7, closes #6, closes #2