### PR TITLE
Fix GraalVM CI: use JDK 23, handle renaissance failures, non-blocking pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ concurrency:
 
 env:
   JAVA_VERSION: '21'
+  GRAALVM_VERSION: '23'
   PYTHON_VERSION: '3.11'
   ARTIFACT_RETENTION_DAYS: 90
   LOG_RETENTION_DAYS: 30
@@ -475,7 +476,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: graalvm
-          java-version: ${{ env.JAVA_VERSION }}
+          java-version: ${{ env.GRAALVM_VERSION }}
 
       - name: Get cache key info
         id: cache-info
@@ -537,7 +538,7 @@ jobs:
       needs.test.result == 'success' &&
       (needs.create-jfr-linux.result == 'success' || needs.create-jfr-linux.result == 'skipped') &&
       (needs.create-jfr-other.result == 'success' || needs.create-jfr-other.result == 'skipped') &&
-      (needs.create-jfr-graal.result == 'success' || needs.create-jfr-graal.result == 'skipped')
+      (needs.create-jfr-graal.result == 'success' || needs.create-jfr-graal.result == 'skipped' || needs.create-jfr-graal.result == 'failure')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     outputs:
@@ -886,9 +887,14 @@ jobs:
             echo "=== JAR Contents Preview ==="
             unzip -l "$INSTALLED_JAR" | grep "me/bechberger/collector/xml" | head -10 || echo "WARNING: No xml package found in JAR"
           else
-            echo "=== Website-only rebuild: Using dependency from pom.xml ==="
-            echo "No build artifacts found. Maven will resolve jfreventcollection from configured repositories."
-            echo "This is expected for website-only rebuilds."
+            echo "=== Website-only rebuild: checking Maven cache for jfreventcollection ==="
+            CACHED_JAR=$(find "$HOME/.m2/repository/me/bechberger/jfreventcollection" -name "*.jar" -not -name "*-sources.jar" -not -name "*-javadoc.jar" 2>/dev/null | head -1)
+            if [ -z "$CACHED_JAR" ]; then
+              echo "ERROR: jfreventcollection not found in Maven cache and no build artifacts present."
+              echo "Run the full build (not website-only) at least once to populate the cache."
+              exit 1
+            fi
+            echo "✓ Found jfreventcollection in Maven cache: $CACHED_JAR"
           fi
 
       - name: Build website generator and generate site

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -777,6 +777,7 @@ jobs:
     needs: [changes, build]
     if: |
       always() &&
+      github.repository == 'SAP/jfrevents' &&
       github.ref == 'refs/heads/main' &&
       (needs.build.result == 'success' || (needs.changes.outputs.website == 'true' && needs.build.result == 'skipped'))
     runs-on: ubuntu-latest
@@ -905,17 +906,14 @@ jobs:
           java -jar target/jfrevents-site-generator.jar generate site --hide-missing-descriptions
 
       - name: Set up Pages
-        if: github.repository == 'SAP/jfrevents'
         uses: actions/configure-pages@v4
 
       - name: Upload pages artifact
-        if: github.repository == 'SAP/jfrevents'
         uses: actions/upload-pages-artifact@v3
         with:
           path: 'website/site'
 
       - name: Deploy to GitHub Pages
-        if: github.repository == 'SAP/jfrevents'
         id: deployment
         uses: actions/deploy-pages@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  JAVA_VERSION: '21'
+  JAVA_VERSION: '25'
   GRAALVM_VERSION: '23'
   PYTHON_VERSION: '3.11'
   ARTIFACT_RETENTION_DAYS: 90

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -905,14 +905,17 @@ jobs:
           java -jar target/jfrevents-site-generator.jar generate site --hide-missing-descriptions
 
       - name: Set up Pages
+        if: github.repository == 'SAP/jfrevents'
         uses: actions/configure-pages@v4
 
       - name: Upload pages artifact
+        if: github.repository == 'SAP/jfrevents'
         uses: actions/upload-pages-artifact@v3
         with:
           path: 'website/site'
 
       - name: Deploy to GitHub Pages
+        if: github.repository == 'SAP/jfrevents'
         id: deployment
         uses: actions/deploy-pages@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -589,9 +589,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .cache
-          key: jfr-cache-java${{ steps.cache-info.outputs.java-version }}-v2
+          key: jfr-cache-${{ steps.cache-info.outputs.month }}-java${{ steps.cache-info.outputs.java-version }}
           restore-keys: |
-            jfr-cache-java${{ steps.cache-info.outputs.java-version }}-
             jfr-cache-
 
       - name: Cache Maven dependencies

--- a/bin/releaser.py
+++ b/bin/releaser.py
@@ -654,8 +654,19 @@ def create_jfr_graalvm_native():
     os.makedirs(GRAALVM_SAMPLE_APP_OUT, exist_ok=True)
     execute(f"javac -d {GRAALVM_SAMPLE_APP_OUT} {GRAALVM_SAMPLE_APP_SRC}")
     execute(f"jar -cfe {GRAALVM_SAMPLE_APP_JAR} jfr_sample.Main -C {GRAALVM_SAMPLE_APP_OUT} .")
-    execute(f"native-image --enable-monitoring=jfr -jar {GRAALVM_SAMPLE_APP_JAR} "
+    java_home = os.getenv("JAVA_HOME", "")
+    native_image = os.path.join(java_home, "bin", "native-image") if java_home else "native-image"
+    execute(f"{native_image} --enable-monitoring=jfr -jar {GRAALVM_SAMPLE_APP_JAR} "
             f"{GRAALVM_SAMPLE_APP_BIN}")
+    # Verify JFR was compiled in before running the full benchmark
+    result = subprocess.run([GRAALVM_SAMPLE_APP_BIN, "-XX:PrintFlags="],
+                            capture_output=True, text=True, cwd=CURRENT_DIR)
+    if "StartFlightRecording" not in result.stdout and "StartFlightRecording" not in result.stderr:
+        raise RuntimeError(
+            f"Native image was built without JFR support (--enable-monitoring=jfr had no effect). "
+            f"native-image binary used: {native_image}\n"
+            f"PrintFlags output: {result.stdout[:500]}\n{result.stderr[:500]}"
+        )
     execute([GRAALVM_SAMPLE_APP_BIN,
              f"-XX:StartFlightRecording=filename={jfr_file},settings={JFC_FILE},duration=18s"])
 
@@ -675,9 +686,14 @@ def create_jfr_graal(force: bool = False):
         if os.path.exists(jfr_file) and not force:
             print(f"GraalVM JVM JFR file already exists: {jfr_file}")
             return
-        execute(["java",
-                 f"-XX:StartFlightRecording=filename={jfr_file},settings={JFC_FILE}",
-                 "-XX:+" + gc_option, "-jar", RENAISSANCE_JAR, "-t", "5", "-r", "1", "all"])
+        try:
+            execute(["java",
+                     f"-XX:StartFlightRecording=filename={jfr_file},settings={JFC_FILE}",
+                     "-XX:+" + gc_option, "-jar", RENAISSANCE_JAR, "-t", "5", "-r", "1", "all"])
+        except subprocess.CalledProcessError as ex:
+            if not os.path.exists(jfr_file):
+                raise ex
+            print(f"Caught a Java error (renaissance benchmark failures); JFR file was still produced.", file=sys.stderr)
 
 
 def add_graal_examples(repo: Repo):

--- a/bin/releaser.py
+++ b/bin/releaser.py
@@ -55,7 +55,7 @@ Environment variables:
 CURRENT_DIR = os.path.abspath(
     os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 
-MIN_JAVA_VERSION = 21 # minimum Java version to use for building and running
+MIN_JAVA_VERSION = 25 # minimum Java version to use for building and running
 CACHE_DIR = f"{CURRENT_DIR}/.cache"
 CACHE_TIME = 60 * 60 * 24  # one day
 RENAISSANCE_JAR = f"{CACHE_DIR}/renaissance.jar"


### PR DESCRIPTION
## What broke

1. **GraalVM native JFR** — GraalVM JDK 21.0.11 silently ignores `--enable-monitoring=jfr`; native binary built without JFR support.
2. **Deploy Website** — blocked when GraalVM job fails (Build Collector was skipped).

## Fixes

- Bump `JAVA_VERSION` to `25` (SapMachine); add `GRAALVM_VERSION: '23'` for GraalVM jobs (JDK 23 has working native JFR).
- Allow Build Collector/Deploy Website to run even when `create-jfr-graal` fails.
- Fail fast with a clear error on website-only rebuilds when `jfreventcollection` is missing from Maven cache.
- Use `$JAVA_HOME/bin/native-image` explicitly and verify JFR support post-build.
- Wrap GraalVM JVM renaissance run in `try/except` — JDK 23+ removed the security manager so some benchmarks fail, but the JFR file is still produced.

## Tested

`parttimenerd/jfrevents` fork: GraalVM native ✅, GraalVM jvm ✅, Build Collector ✅, JDK 25 ✅.