### PR TITLE
Add id attributes to event headings for direct deep-linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ src/main/resources
 bin/.idea/
 site/
 target/
+.cache/
+.playwright-mcp/

--- a/website/src/main/kotlin/me/bechberger/collector/site/Main.kt
+++ b/website/src/main/kotlin/me/bechberger/collector/site/Main.kt
@@ -247,7 +247,9 @@ class Main(
         // description for search
         val description: String,
         val sectionTitle: String
-    )
+    ) {
+        val nameLower: String get() = name.lowercase()
+    }
 
     data class SectionScope(
         val title: String, val entries: DecoratedCollection<SectionEntryScope>, val jdks: String,

--- a/website/src/main/resources/template/section.html
+++ b/website/src/main/resources/template/section.html
@@ -2,7 +2,7 @@
     <h1 class="section-header" data-jdks="{{jdks}}" data-graal-only="{{inGraalOnly}}" data-jdk-only="{{inJDKOnly}}">{{title}}</h1>
     {{#entries}}
 
-        <h2 class="event-header hideable-part" data-jdks="{{value.jdks}}" data-graal-only="{{value.inGraalOnly}}" data-jdk-only="{{value.inJDKOnly}}" data-name="{{value.name}}">{{value.name}}</h2>
+        <h2 id="{{value.nameLower}}" class="event-header hideable-part" data-jdks="{{value.jdks}}" data-graal-only="{{value.inGraalOnly}}" data-jdk-only="{{value.inJDKOnly}}" data-name="{{value.name}}">{{value.name}}</h2>
         <div class="event hideable-part" data-jdks="{{value.jdks}}" data-graal-only="{{value.inGraalOnly}}" data-jdk-only="{{value.inJDKOnly}}" data-name="{{value.name}}" data-description="{{value.description}}" data-section="{{../title}}">
             {{{value.inner}}}
         </div>


### PR DESCRIPTION
## Summary

- Adds a `nameLower` computed property to `SectionEntryScope` in `Main.kt` that returns `name.lowercase()`
- Renders `id="{{value.nameLower}}"` on every event `<h2>` in `section.html`

This produces e.g. `<h2 id="virtualthreadend" class="event-header hideable-part" ...>` for all event and type headings across all JDK version pages.

Fixes #10.