### PR TITLE
fix(ci): bump Renaissance from 0.15.0 to 0.16.1 to fix getSubject on JDK 25+

### DIFF
--- a/bin/releaser.py
+++ b/bin/releaser.py
@@ -346,7 +346,7 @@ def download_graal_version(version: GraalVersion) -> Path:
 
 def download_benchmarks():
     download_file("https://github.com/renaissance-benchmarks"
-                  "/renaissance/releases/download/v0.15.0/renaissance-gpl-0.15.0.jar",
+                  "/renaissance/releases/download/v0.16.1/renaissance-gpl-0.16.1.jar",
                   RENAISSANCE_JAR)
 
 

--- a/bin/releaser.py
+++ b/bin/releaser.py
@@ -454,8 +454,9 @@ def run_sample_app_jfr(gc_option: str, platform: str = None):
     jfr_file = jfr_sample_app_file_name(gc_option, platform)
     os.makedirs(out_dir, exist_ok=True)
     if not os.path.exists(app_jar):
+        src_dir = os.path.dirname(GRAALVM_SAMPLE_APP_SRC)
         execute(f"javac --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED "
-                f"-d {out_dir} {GRAALVM_SAMPLE_APP_SRC}")
+                f"-d {out_dir} {src_dir}/*.java")
         execute(f"jar -cfe {app_jar} jfr_sample.Main -C {out_dir} .")
     execute(["java",
              "--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED",


### PR DESCRIPTION
## Summary

- Bumps Renaissance benchmark from v0.15.0 to v0.16.1
- Fixes scheduled CI failures on Windows (`windows-latest`) where `page-rank`, `movie-lens`, `chi-square`, `dec-tree` benchmarks crash with `java.lang.UnsupportedOperationException: getSubject is not supported`
- Root cause: `Subject.getSubject()` was removed in JDK 25; Renaissance 0.16.1 is the first release that does not use it

The cache key for the Renaissance JAR is based on `hashFiles('bin/releaser.py')` so it will automatically invalidate and re-download.